### PR TITLE
feat(societal_values): Make societal value behave like estate satisfaction equilibrium

### DIFF
--- a/in_game/common/on_action/on_actions_CENSUS.txt
+++ b/in_game/common/on_action/on_actions_CENSUS.txt
@@ -1,0 +1,5 @@
+﻿monthly_country_pulse = {
+    events = {
+        societal_values_balancing_feedback_loop.01
+    }
+}

--- a/in_game/common/scripted_effects/societal_values_feedback_loop_scripted_effects.txt
+++ b/in_game/common/scripted_effects/societal_values_feedback_loop_scripted_effects.txt
@@ -1,0 +1,39 @@
+﻿iterate_societal_values = {
+    societal_value_balance = { SV_LEFT = centralization SV_RIGHT = decentralization }
+    societal_value_balance = { SV_LEFT = traditionalist SV_RIGHT = innovative }
+    societal_value_balance = { SV_LEFT = spiritualist SV_RIGHT = humanist }
+    societal_value_balance = { SV_LEFT = aristocracy SV_RIGHT = plutocracy }
+    societal_value_balance = { SV_LEFT = serfdom SV_RIGHT = free_subjects }
+    societal_value_balance = { SV_LEFT = mercantilism SV_RIGHT = free_trade }
+    societal_value_balance = { SV_LEFT = belligerent SV_RIGHT = conciliatory }
+    societal_value_balance = { SV_LEFT = quality SV_RIGHT = quantity }
+    societal_value_balance = { SV_LEFT = offensive SV_RIGHT = defensive }
+    societal_value_balance = { SV_LEFT = land SV_RIGHT = naval }
+    societal_value_balance = { SV_LEFT = capital_economy SV_RIGHT = traditional_economy }
+    societal_value_balance = { SV_LEFT = individualism SV_RIGHT = communalism }
+    societal_value_balance = { SV_LEFT = outward SV_RIGHT = inward }
+    societal_value_balance = { SV_LEFT = sinicized SV_RIGHT = unsinicized }
+    societal_value_balance = { SV_LEFT = absolutism SV_RIGHT = liberalism }
+    societal_value_balance = { SV_LEFT = mysticism SV_RIGHT = jurisprudence }
+}
+
+societal_value_balance = {
+    if = {
+        limit = { has_societal_value = societal_value_type:$SV_LEFT$_vs_$SV_RIGHT$ }
+
+        change_societal_value = {
+            value = {
+                subtract = societal_value:$SV_LEFT$_vs_$SV_RIGHT$
+                subtract = {
+                    value = modifier:monthly_towards_$SV_LEFT$
+                    multiply = 100
+                }
+                add = {
+                    value = modifier:monthly_towards_$SV_RIGHT$
+                    multiply = 100
+                }
+                multiply = 0.01
+            }
+            type = $SV_LEFT$_vs_$SV_RIGHT$ }
+    }
+}

--- a/in_game/events/societal_values_balancing_feedback_loop.txt
+++ b/in_game/events/societal_values_balancing_feedback_loop.txt
@@ -1,0 +1,8 @@
+﻿namespace = societal_values_balancing_feedback_loop
+
+societal_values_balancing_feedback_loop.01 = {
+    hidden = yes
+    immediate = {
+        iterate_societal_values = yes
+    }
+}


### PR DESCRIPTION
e.g. there is 75 Aristocracy & a trend towards Aristocracy of 0.5.

In vanilla, it stays at 75, until trend has different sign. 
If it's less than that, it will increase to 50.
If it's more than 50, it maintains.

With this change, it will gravitate towards 50.
If a negative event brings it to 40, it will slowly go back to 50.