### PR TITLE
Add logs for total population, building type count & prices, for every region + Add PyQt6 plotter with filters & hotkeys

### DIFF
--- a/in_game/common/on_action/on_actions_CENSUS.txt
+++ b/in_game/common/on_action/on_actions_CENSUS.txt
@@ -1,0 +1,11 @@
+﻿on_monthly_pulse_country = {
+    events = {
+        LOGGER_CHARTS.02
+    }
+}
+
+on_game_started = {
+    events = {
+        LOGGER_CHARTS.03
+    }
+}

--- a/in_game/common/on_action/on_actions_CENSUS.txt
+++ b/in_game/common/on_action/on_actions_CENSUS.txt
@@ -11,8 +11,7 @@ on_game_start_MnT = {
 	}
 }
 
-
-monthly_country_pulse = {
+yearly_country_pulse = {
 	trigger = { c:FRA ?= this }
 	on_actions = {
 		once_per_month

--- a/in_game/common/on_action/on_actions_CENSUS.txt
+++ b/in_game/common/on_action/on_actions_CENSUS.txt
@@ -1,11 +1,29 @@
-﻿on_monthly_pulse_country = {
-    events = {
-        LOGGER_CHARTS.02
-    }
+﻿on_game_start = {
+	on_actions = {
+		on_game_start_MnT
+	}
+}
+on_game_start_MnT = {
+	effect = {
+		c:FRA = {
+			trigger_event_silently = { id = LOGGER_CHARTS.03 }
+		}
+	}
 }
 
-on_game_started = {
-    events = {
-        LOGGER_CHARTS.03
-    }
+
+monthly_country_pulse = {
+	trigger = { c:FRA ?= this }
+	on_actions = {
+		once_per_month
+	}
+}
+
+once_per_month = {
+	trigger = { c:FRA ?= this }
+	effect = {
+		c:FRA = {
+			trigger_event_silently = { id = LOGGER_CHARTS.02 }
+		}
+	}
 }

--- a/in_game/common/scripted_effects/SYS-scripted_effect.txt
+++ b/in_game/common/scripted_effects/SYS-scripted_effect.txt
@@ -1,0 +1,55 @@
+#TODO: for every region & good, get prices
+
+run_logging = {
+    # print_building_types = yes
+    # print_population = yes
+    # print_prices = yes
+}
+
+print_population = {
+    every_region = {
+        debug_log = "::POP:[THIS.GetRegion.GetNameWithNoTooltip]:[THIS.GetRegion.GetTotalPopulation]"
+    }
+}
+
+print_prices = {
+    every_goods = {
+        set_local_variable = { name = good_curr value = this }
+        every_region = {
+            set_local_variable = {
+                name = avg_cost
+                value = {
+                    every_location_in_region = {
+                        add = "market.market_price(local_var:good_curr)"
+                    }
+                }
+            }
+            debug_log = "::GP:[PREV.GetGoods.GetNameWithNoTooltip]:[THIS.GetRegion.GetNameWithNoTooltip]:[SCOPE.GetLocalVariable('avg_cost').GetValue]"
+        }
+    }
+}
+
+print_building_types = {
+    every_building_type = {
+        set_local_variable = { name = bldg_curr value = this }
+        every_region = {
+            set_local_variable = {
+                name = bldg_count
+                value = {
+                    every_location_in_region = {
+                        every_buildings_in_location = {
+                            limit = { building_type = local_var:bldg_curr }
+                            add = building_level
+                        }
+
+                    }
+                }
+            }
+
+            if = {
+                limit = { local_var:bldg_count > 0 }
+                debug_log = "::BT:[GetGlobalVariable('month').GetValue]:[SCOPE.GetLocalVariable('bldg_curr').GetBuildingType.GetNameWithNoTooltip]:[SCOPE.GetLocalVariable('bldg_count').GetValue]:[THIS.GetRegion.GetNameWithNoTooltip]"
+            }
+        }
+    }
+}

--- a/in_game/common/scripted_effects/SYS-scripted_effect.txt
+++ b/in_game/common/scripted_effects/SYS-scripted_effect.txt
@@ -4,13 +4,13 @@
 		print_building_types = yes        # characters at start: 147,474
 		print_population = yes            # characters at start:   9,505
 		print_prices = yes                # characters at start: 765,974
-		debug_log = "::Done logging for this month"
+		debug_log = "::Done logging for this year"
 	}
 }
 
 print_population = {
     every_region = {
-        debug_log = "::POP::[GetGlobalVariable('month').GetValue]:[THIS.GetRegion.GetNameWithNoTooltip]:[THIS.GetRegion.GetTotalPopulation]"
+        debug_log = "::POP::[GetCurrentYear]:[THIS.GetRegion.GetNameWithNoTooltip]:[THIS.GetRegion.GetTotalPopulation]"
     }
 }
 
@@ -32,7 +32,7 @@ print_prices = {
 			}
 			if = {
 				limit = { location_counter > 0 }
-				debug_log = "::GP::[GetGlobalVariable('month').GetValue]:[PREV.GetGoods.GetNameWithNoTooltip]:[THIS.GetRegion.GetNameWithNoTooltip]:[SCOPE.GetLocalVariable('avg_cost').GetValue]"
+				debug_log = "::GP::[GetCurrentYear]:[PREV.GetGoods.GetNameWithNoTooltip]:[THIS.GetRegion.GetNameWithNoTooltip]:[SCOPE.GetLocalVariable('avg_cost').GetValue]"
 			}
 		}
 	}
@@ -57,7 +57,7 @@ print_building_types = {
 
             if = {
                 limit = { local_var:bldg_count > 0 }
-                debug_log = "::BT:[GetGlobalVariable('month').GetValue]:[SCOPE.GetLocalVariable('bldg_curr').GetBuildingType.GetNameWithNoTooltip]:[SCOPE.GetLocalVariable('bldg_count').GetValue]:[THIS.GetRegion.GetNameWithNoTooltip]"
+                debug_log = "::BT:[GetCurrentYear]:[SCOPE.GetLocalVariable('bldg_curr').GetBuildingType.GetNameWithNoTooltip]:[SCOPE.GetLocalVariable('bldg_count').GetValue]:[THIS.GetRegion.GetNameWithNoTooltip]"
             }
         }
     }

--- a/in_game/common/scripted_effects/SYS-scripted_effect.txt
+++ b/in_game/common/scripted_effects/SYS-scripted_effect.txt
@@ -1,32 +1,41 @@
-#TODO: for every region & good, get prices
-
-run_logging = {
-    # print_building_types = yes
-    # print_population = yes
-    # print_prices = yes
+﻿run_logging = {
+	if = {
+		limit = { has_global_variable = is_logging_enabled}
+		print_building_types = yes        # characters at start: 147,474
+		print_population = yes            # characters at start:   9,505
+		print_prices = yes                # characters at start: 765,974
+		debug_log = "::Done logging for this month"
+	}
 }
 
 print_population = {
     every_region = {
-        debug_log = "::POP:[THIS.GetRegion.GetNameWithNoTooltip]:[THIS.GetRegion.GetTotalPopulation]"
+        debug_log = "::POP::[GetGlobalVariable('month').GetValue]:[THIS.GetRegion.GetNameWithNoTooltip]:[THIS.GetRegion.GetTotalPopulation]"
     }
 }
 
 print_prices = {
-    every_goods = {
-        set_local_variable = { name = good_curr value = this }
-        every_region = {
-            set_local_variable = {
-                name = avg_cost
-                value = {
-                    every_location_in_region = {
-                        add = "market.market_price(local_var:good_curr)"
-                    }
-                }
-            }
-            debug_log = "::GP:[PREV.GetGoods.GetNameWithNoTooltip]:[THIS.GetRegion.GetNameWithNoTooltip]:[SCOPE.GetLocalVariable('avg_cost').GetValue]"
-        }
-    }
+	every_goods = {
+		# limit = { this = goods:wheat }
+		save_scope_as = good_curr
+		every_region = {
+			set_local_variable = {
+				name = avg_cost
+				value = {
+					every_location_in_region = {
+						limit = { is_land = yes }
+						add = "market.market_price(scope:good_curr)"
+					}
+					divide = location_counter
+				}
+
+			}
+			if = {
+				limit = { location_counter > 0 }
+				debug_log = "::GP::[GetGlobalVariable('month').GetValue]:[PREV.GetGoods.GetNameWithNoTooltip]:[THIS.GetRegion.GetNameWithNoTooltip]:[SCOPE.GetLocalVariable('avg_cost').GetValue]"
+			}
+		}
+	}
 }
 
 print_building_types = {

--- a/in_game/events/SYS-CENSUS.txt
+++ b/in_game/events/SYS-CENSUS.txt
@@ -1,30 +1,49 @@
-namespace = LOGGER_CHARTS
+﻿namespace = LOGGER_CHARTS
 
 # wealth, buildings, productions, pops on a market basis
 
-# for debugging purposes -forces logs to happen, where otherwise they get stuck until a certain point
-LOGGER_CHARTS.FORCE_LOGGING = {
+# Force writting another chunk
+LOGGER_CHARTS.01 = {
     hidden = yes
     immediate = {
         debug_log = ""
     }
 }
 
+# Continue logging
 LOGGER_CHARTS.02 = {
     type = country_event
     hidden = yes
-
     immediate = {
-        change_global_variable = { name = month add = 1 }
+		change_global_variable = { name = month add = 1 }
         run_logging = yes
     }
 }
 
+# Prepare logging
 LOGGER_CHARTS.03 = {
     type = country_event
     hidden = yes
     immediate = {
-        set_global_variable = { name = month value = 0 }
+        set_global_variable = { name = month value = 4 }
         run_logging = yes
     }
+}
+
+# Disable logging
+LOGGER_CHARTS.04 = {
+	type = country_event
+	hidden = yes
+	immediate = {
+		set_global_variable = is_logging_enabled
+	}
+}
+
+# Enable logging
+LOGGER_CHARTS.05 = {
+	type = country_event
+	hidden = yes
+	immediate = {
+		remove_global_variable = is_logging_enabled
+	}
 }

--- a/in_game/events/SYS-CENSUS.txt
+++ b/in_game/events/SYS-CENSUS.txt
@@ -1,0 +1,30 @@
+namespace = LOGGER_CHARTS
+
+# wealth, buildings, productions, pops on a market basis
+
+# for debugging purposes -forces logs to happen, where otherwise they get stuck until a certain point
+LOGGER_CHARTS.FORCE_LOGGING = {
+    hidden = yes
+    immediate = {
+        debug_log = ""
+    }
+}
+
+LOGGER_CHARTS.02 = {
+    type = country_event
+    hidden = yes
+
+    immediate = {
+        change_global_variable = { name = month add = 1 }
+        run_logging = yes
+    }
+}
+
+LOGGER_CHARTS.03 = {
+    type = country_event
+    hidden = yes
+    immediate = {
+        set_global_variable = { name = month value = 0 }
+        run_logging = yes
+    }
+}

--- a/tools/plot/MT_grapher.py
+++ b/tools/plot/MT_grapher.py
@@ -1,0 +1,333 @@
+import configparser
+import glob
+import os
+import sys
+import traceback
+from functools import partial
+
+import re
+from itertools import cycle
+import matplotlib.pyplot as plt
+import numpy as np
+from PyQt6.QtGui import QShortcut, QKeySequence
+from PyQt6.QtWidgets import (QApplication, QDialog, QGridLayout, QHBoxLayout,
+							 QHeaderView, QMainWindow, QPushButton,
+							 QTableWidget, QTableWidgetItem, QVBoxLayout,
+							 QWidget)
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+
+import chart_library as all_graphs
+from interactive_tooltip import InteractiveLineTooltip
+
+CONFIG_FILE = "log_reader_config.ini"
+DEFAULT_LOG_PATH = ''
+TARGET_FILE_NAME_ROOT = 'debug'
+
+graph_introduction = """
+Welcome to the M&T graphing tool!
+
+Press '/' to see the list of available graphs.
+Refresh to read game.log again.
+
+If this is the first run, update the generated config file
+in the same folder & restart.
+"""
+
+class ChartSelectionDialog(QDialog):
+	"""A dialog window to display and select available charts."""
+	def __init__(self, graphs_dict, parent=None):
+		super().__init__(parent)
+		self.setWindowTitle("Select a Chart")
+		self.graphs = graphs_dict
+		self.selected_chart = None
+
+		self.layout = QVBoxLayout(self)
+
+		self.table = QTableWidget()
+		self.table.setColumnCount(2)
+		self.table.setHorizontalHeaderLabels(["Chart Name", "Hotkey"])
+		self.table.setRowCount(len(self.graphs))
+		self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+		self.table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+		self.table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
+		self.table.verticalHeader().setVisible(False)
+		self.table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+
+		self.populate_table()
+
+		self.layout.addWidget(self.table)
+		self.table.cellDoubleClicked.connect(self.on_double_click)
+		self.table.activated.connect(self.on_activated) # Handles Enter key
+
+	def populate_table(self):
+		"""Fills the table with chart names and their assigned hotkeys."""
+		sorted_charts = sorted(self.graphs.keys())
+		for i, chart_name in enumerate(sorted_charts):
+			hotkey = str(i + 1)
+			self.parent().chart_hotkeys[hotkey] = chart_name # Assign hotkey in main window
+			self.table.setItem(i, 0, QTableWidgetItem(chart_name))
+			self.table.setItem(i, 1, QTableWidgetItem(hotkey))
+
+	def on_double_click(self, row, column):
+		"""Sets the selected chart and closes the dialog on double click."""
+		self.accept_selection(row)
+
+	def on_activated(self, index):
+		"""Sets the selected chart and closes the dialog on Enter key press."""
+		self.accept_selection(index.row())
+
+	def accept_selection(self, row):
+		chart_name = self.table.item(row, 0).text()
+		self.selected_chart = chart_name
+		self.accept()
+
+
+class MainWindow(QMainWindow):
+	def __init__(self):
+		super().__init__()
+		self.setWindowTitle("MEIOU and Taxes - Sim graphs")
+		self.setGeometry(100, 100, 1800, 800)
+
+		# --- Data and State ---
+		self.log_folder = get_log_directory_from_config()
+		self.logs = []
+		self.data = ""
+		self.graphs = {}
+		self.chart_hotkeys = {}
+		self.chart_shortcuts = []
+		self.cursor_hover_handler = None
+		self.filter_widgets = []
+
+		# --- Main Layout ---
+		self.central_widget = QWidget()
+		self.setCentralWidget(self.central_widget)
+		self.layout = QVBoxLayout(self.central_widget)
+
+		# --- Matplotlib Canvas ---
+		self.fig, self.ax = plt.subplots()
+		self.canvas = FigureCanvas(self.fig)
+		self.layout.addWidget(self.canvas, 1)
+
+		# --- Matplotlib Toolbar ---
+		self.toolbar = NavigationToolbar(self.canvas, self)
+		self.layout.addWidget(self.toolbar)
+
+		# --- Top Buttons Layout ---
+		button_layout = QHBoxLayout()
+		self.btn_refresh = QPushButton("Refresh data [F5]")
+		self.btn_backup = QPushButton("Backup logs [Ctrl+S]")
+		self.btn_charts = QPushButton("Charts [`]")
+		button_layout.addWidget(self.btn_refresh)
+		button_layout.addWidget(self.btn_backup)
+		button_layout.addWidget(self.btn_charts)
+		button_layout.addStretch(1) # Pushes buttons to the left
+		self.layout.addLayout(button_layout)
+
+		# --- Bottom Filter Widgets Layout ---
+		self.filter_layout = QGridLayout()
+		self.layout.addLayout(self.filter_layout)
+
+		# --- Connect Signals ---
+		self.btn_refresh.clicked.connect(self.reload_log)
+		self.btn_backup.clicked.connect(self.backup_log)
+		self.btn_charts.clicked.connect(self.show_chart_list)
+
+		# --- Initialize ---
+		self.setup_shortcuts()
+		self.load_graph_definitions()
+		self.reload_log()
+
+	def setup_shortcuts(self):
+		"""Setup global keyboard shortcuts."""
+		QShortcut(QKeySequence("F5"), self, self.reload_log)
+		QShortcut(QKeySequence("Ctrl+S"), self, self.backup_log)
+		QShortcut(QKeySequence("`"), self, self.show_chart_list)
+		QShortcut(QKeySequence("F11"), self, self.toggle_fullscreen)
+
+	def toggle_fullscreen(self):
+		"""Toggles the main window between fullscreen and normal modes."""
+		if self.isFullScreen():
+			self.showNormal()
+		else:
+			self.showFullScreen()
+
+	def load_graph_definitions(self):
+		"""Load graph functions from the all_graphs module."""
+		all_graphs.get_data = self.get_data
+		self.graphs = {
+			getattr(all_graphs, name).__name__[5:].replace("_", " "): (
+				getattr(all_graphs, name).__doc__,
+				getattr(all_graphs, name)
+			)
+			for name in dir(all_graphs)
+			if callable(getattr(all_graphs, name)) and name.lower().startswith("graph")
+		}
+		# Setup chart hotkeys (1, 2, 3...)
+		sorted_charts = sorted(self.graphs.keys())
+		self.chart_shortcuts.clear()
+		for i, chart_name in enumerate(sorted_charts):
+			hotkey = str(i + 1)
+			self.chart_hotkeys[hotkey] = chart_name
+			shortcut = QShortcut(QKeySequence(hotkey), self)
+			shortcut.activated.connect(partial(self.plot_by_hotkey, hotkey))
+			self.chart_shortcuts.append(shortcut)
+
+	def plot_by_hotkey(self, key):
+		"""Plots a chart when its numeric hotkey is pressed."""
+		chart_name = self.chart_hotkeys.get(key)
+		if chart_name:
+			title, graph_func = self.graphs[chart_name]
+			self.display_chart(graph_func, title)
+
+	def display_info_screen(self, msg=None):
+		"""Displays the initial welcome message on the plot."""
+		self.cursor_hover_handler = None
+		self.clear_filter_widgets()
+		self.ax.clear()
+		self.ax.set_title("Menu")
+		text_to_show = msg if msg else graph_introduction.strip()
+		self.ax.text(0.5, 0.5, text_to_show,
+					 horizontalalignment="center", verticalalignment="center")
+		self.canvas.draw()
+
+	def get_data(self, _, str_target):
+		"""Read data (passed to all_graphs module)."""
+		lst = []
+		loc = 0
+		while True:
+			loc = self.data.find(str_target, loc)
+			if loc != -1:
+				end = self.data.find("\n", loc)
+				lst.append(float(self.data[loc:end].strip().split(":")[1].strip().split("£")[-1]))
+				loc = end
+			else:
+				break
+		return np.array(lst)
+
+	def clear_filter_widgets(self):
+		"""Removes any dynamically added filter widgets from the layout."""
+		for widget in self.filter_widgets:
+			self.filter_layout.removeWidget(widget)
+			widget.deleteLater()
+		self.filter_widgets.clear()
+
+	def setup_tooltip_handler(self):
+		"""Creates a new tooltip handler for the current axes."""
+		self.cursor_hover_handler = InteractiveLineTooltip(self.ax)
+		self.cursor_hover_handler.setup_tooltip_handler()
+
+	def clear_tooltip_handler(self):
+		"""Clears any existing tooltip handler."""
+		self.cursor_hover_handler = None
+
+	def display_chart(self, graph_func, title):
+		"""Clears the axes and plots a new graph."""
+		self.clear_filter_widgets()
+		self.ax.clear()
+		self.fig.subplots_adjust(bottom=0.1, left=0.05, right=0.95, top=0.925) # Reset adjustments
+
+		try:
+			graph_func(
+				self.data,
+				self.ax,
+				self.filter_layout,
+				self.filter_widgets,
+				self.setup_tooltip_handler,
+				self.clear_tooltip_handler
+			)
+			self.ax.set_title(title)
+			self.canvas.draw() # Draw the canvas first, to update the graph elements
+
+		except Exception as e:
+			self.ax.text(0.5, 0.5, f"Error:\n{e}", ha='center', va='center')
+			traceback.print_exc()
+
+		self.ax.set_title(title)
+		self.canvas.draw()
+
+	def backup_log(self):
+		"""Backs up the current game.log."""
+		if not self.logs:
+			print("No log files found to determine the next backup number.")
+			return
+		last_log_num = int(os.path.basename(self.logs[-1])[5:-4])
+		try:
+			os.rename("game.log", f"game_{last_log_num + 1}.log")
+			print(f"Backed up game.log to game_{last_log_num + 1}.log")
+		except FileNotFoundError:
+			print("game.log not found, nothing to back up.")
+		except Exception as e:
+			print(f"Error backing up log: {e}")
+		self.display_info_screen()
+
+	def reload_log(self):
+		"""Reads all log files from the configured directory."""
+		self.logs, self.data = read_all_logs(self.log_folder)
+		self.display_info_screen()
+
+	def show_chart_list(self):
+		"""Opens the chart selection dialog."""
+		dialog = ChartSelectionDialog(self.graphs, self)
+		if dialog.exec() == QDialog.DialogCode.Accepted and dialog.selected_chart:
+			chart_name = dialog.selected_chart
+			title, graph_func = self.graphs[chart_name]
+			self.display_chart(graph_func, title)
+
+
+def read_all_logs(log_directory):
+	"""Read file(s) from a specified directory."""
+	content_list = []
+	search_pattern = os.path.join(log_directory, TARGET_FILE_NAME_ROOT + "_*.log")
+	files = glob.glob(search_pattern)
+	if files:
+		files.sort(key=lambda x: int(os.path.basename(x)[5:-4]))
+
+	for fn in files:
+		with open(fn, "r", encoding="utf-8") as f:
+			content_list.append(f.read())
+
+	game_log_path = os.path.join(log_directory, f"{TARGET_FILE_NAME_ROOT}.log")
+	try:
+		with open(game_log_path, "r", encoding="utf-8") as f:
+			content_list.append(f.read())
+	except FileNotFoundError:
+		print(f"WARNING: Could not find {game_log_path}")
+
+	print(f'Read {len(files) + (1 if os.path.exists(game_log_path) else 0)} log file(s) from "{log_directory}"')
+	return files, "".join(content_list)
+
+
+def get_log_directory_from_config():
+	"""Reads the log directory path from the config file."""
+	config = configparser.ConfigParser()
+	if os.path.exists(CONFIG_FILE):
+		try:
+			config.read(CONFIG_FILE)
+			return config.get('Paths', 'log_directory')
+		except (configparser.NoSectionError, configparser.NoOptionError):
+			pass
+
+	config['Paths'] = {'log_directory': DEFAULT_LOG_PATH}
+	try:
+		with open(CONFIG_FILE, 'w') as configfile:
+			config.write(configfile)
+	except Exception as e:
+		print(f"ERROR: Could not write config file: {e}")
+	return DEFAULT_LOG_PATH
+
+
+if __name__ == '__main__':
+	try:
+		# Must change directory to script's location for config/log files
+		os.chdir(os.path.dirname(__file__) or '.')
+
+		app = QApplication(sys.argv)
+		main_window = MainWindow()
+		main_window.show()
+		sys.exit(app.exec())
+
+	except Exception as e:
+		print(e)
+		traceback.print_exc()
+		input("\nPress enter to close...")

--- a/tools/plot/chart_library.py
+++ b/tools/plot/chart_library.py
@@ -6,10 +6,12 @@ from PyQt6.QtWidgets import QLabel, QComboBox
 
 from tools.plot.custom_widgets import RightClickableComboBox
 from tools.plot.log_parser import parse_data_goods_prices, parse_data_building_types, parse_data_population
+from matplotlib.ticker import MaxNLocator
 
-FIRST_MONTH = 5 # Makes FIRST_MONTH-1 not have 0 buildings in all regions
+IS_LOGGING_YEARLY = True
+FIRST_MOMENT = 1 + 1337 if IS_LOGGING_YEARLY else 4 # Makes FIRST_MOMENT-1 not have 0 buildings in all regions
 
-STR_ALL_MONTHS = "All months"
+STR_ALL_MOMENTS = "All moments"
 STR_ALL_BUILDINGS = "All buildings"
 STR_ALL_REGIONS = "All regions"
 STR_ALL_GOODS = "All goods"
@@ -42,11 +44,11 @@ def _create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines
 	ComboBoxClass = RightClickableComboBox if config.get("use_right_click_combo", True) else QComboBox
 
 	# --- Create Interactive PyQt Widgets ---
-	lbl_month = QLabel("Month:")
-	combo_month = ComboBoxClass()
-	all_months = sorted(list(set(item['month'] for item in all_data)))
-	combo_month.addItem(STR_ALL_MONTHS)
-	combo_month.addItems([str(m) for m in all_months])
+	lbl_moment = QLabel("Time:")
+	combo_moment = ComboBoxClass()
+	all_moments = sorted(list(set(item['moment'] for item in all_data)))
+	combo_moment.addItem(STR_ALL_MOMENTS)
+	combo_moment.addItems([str(m) for m in all_moments])
 
 	lbl_category = QLabel(category_label_str)
 	combo_category = ComboBoxClass()
@@ -61,19 +63,19 @@ def _create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines
 	combo_region.addItems(all_regions)
 
 	# Add widgets to the layout
-	filter_layout.addWidget(lbl_month, 0, 0)
-	filter_layout.addWidget(combo_month, 0, 1)
+	filter_layout.addWidget(lbl_moment, 0, 0)
+	filter_layout.addWidget(combo_moment, 0, 1)
 	filter_layout.addWidget(lbl_category, 0, 2)
 	filter_layout.addWidget(combo_category, 0, 3)
 	filter_layout.addWidget(lbl_region, 0, 4)
 	filter_layout.addWidget(combo_region, 0, 5)
 	filter_layout.setColumnStretch(6, 1)
 
-	filter_widgets_list.extend([lbl_month, combo_month, lbl_category, combo_category, lbl_region, combo_region])
+	filter_widgets_list.extend([lbl_moment, combo_moment, lbl_category, combo_category, lbl_region, combo_region])
 
 	def update_plot():
 		on_plot_cleared()
-		filter_month_str = combo_month.currentText()
+		filter_moment_str = combo_moment.currentText()
 		filter_category_type = combo_category.currentText()
 		filter_region = combo_region.currentText()
 		ax.clear()
@@ -86,7 +88,7 @@ def _create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines
 
 		filtered_data = [
 			item for item in all_data
-			if (filter_month_str == STR_ALL_MONTHS or item['month'] == int(filter_month_str)) and
+			if (filter_moment_str == STR_ALL_MOMENTS or item['moment'] == int(filter_moment_str)) and
 			   (filter_category_type == all_category_str or filter_category_type == item[category_key]) and
 			   (filter_region == STR_ALL_REGIONS or filter_region == item['region'])
 		]
@@ -96,45 +98,55 @@ def _create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines
 			ax.figure.canvas.draw_idle()
 			return
 
-		is_month_all = filter_month_str == STR_ALL_MONTHS
+		is_moment_all = filter_moment_str == STR_ALL_MOMENTS
 		is_category_picked = filter_category_type != all_category_str
 		is_region_picked = filter_region != STR_ALL_REGIONS
 		prop_cycle = plt.rcParams['axes.prop_cycle']
 		colors = cycle(prop_cycle.by_key()['color'])
 
 		# --- Line Graph Logic ---
-		if is_month_all and (is_category_picked or is_region_picked):
+		if is_moment_all and (is_category_picked or is_region_picked):
 			plot_category_key = category_key if is_region_picked else 'region'
 			data_to_plot = {}
 			for item in filtered_data:
 				key = item[plot_category_key]
 				if key not in data_to_plot:
-					data_to_plot[key] = {'months': [], 'values': []}
-				data_to_plot[key]['months'].append(item['month'])
+					data_to_plot[key] = {'moments': [], 'values': []}
+				data_to_plot[key]['moments'].append(item['moment'])
 				data_to_plot[key]['values'].append(item[value_key])
 
-			if add_zero_start:
+
+			if add_zero_start and data_to_plot:
+				# First, find the earliest moment across ALL lines being plotted.
+				all_moments = [moment for v in data_to_plot.values() for moment in v['moments']]
+				if not all_moments: return # Should not happen if data_to_plot is not empty, but safe to have
+
+				overall_min_moment = min(all_moments)
+
+				# Now, add a zero-point only if a line starts AFTER that earliest moment.
 				for _, values in data_to_plot.items():
-					if not values['months']: continue
-					min_month = min(values['months'])
-					if min_month != FIRST_MONTH:
-						values['months'].append(min_month - 1)
+					if not values['moments']: continue
+
+					line_min_moment = min(values['moments'])
+					if line_min_moment > overall_min_moment:
+						values['moments'].append(line_min_moment - 1)
 						values['values'].append(0)
 
-			ax.set_xlabel("Month")
+			ax.set_xlabel("Time")
+			ax.xaxis.set_major_locator(MaxNLocator(integer=True))
 			ax.set_ylabel(value_label_str)
 			title_text = f"{value_label_str}s for: {filter_category_type}" if is_category_picked else f"{value_label_str}s in: {filter_region}"
 			ax.set_title(title_text)
 
 			for name, values in sorted(data_to_plot.items()):
-				if not values['months']: continue
-				sorted_points = sorted(zip(values['months'], values['values']))
-				months_sorted, values_sorted = zip(*sorted_points)
-				ax.plot(months_sorted, values_sorted, marker='o', linestyle='-', label=name, color=next(colors))
+				if not values['moments']: continue
+				sorted_points = sorted(zip(values['moments'], values['values']))
+				moments_sorted, values_sorted = zip(*sorted_points)
+				ax.plot(moments_sorted, values_sorted, marker='o', linestyle='-', label=name, color=next(colors))
 
 			if data_to_plot:
-				min_x = min(min(v['months']) for v in data_to_plot.values() if v['months'])
-				max_x = max(max(v['months']) for v in data_to_plot.values() if v['months'])
+				min_x = min(min(v['moments']) for v in data_to_plot.values() if v['moments'])
+				max_x = max(max(v['moments']) for v in data_to_plot.values() if v['moments'])
 				ax.set_xlim(min_x, max_x)
 
 			if SHOW_LEGEND and data_to_plot:
@@ -143,7 +155,7 @@ def _create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines
 			on_lines_plotted()
 
 		# --- Bar Graph Logic ---
-		elif not is_month_all and (is_category_picked or is_region_picked):
+		elif not is_moment_all and (is_category_picked or is_region_picked):
 			coloring_key = category_key if is_region_picked else 'region'
 			unique_items = sorted(list(set(item[coloring_key] for item in filtered_data)))
 			color_map = {name: next(colors) for name in unique_items}
@@ -153,7 +165,7 @@ def _create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines
 
 			ax.bar(labels, values, color=bar_colors)
 			ax.set_ylabel(value_label_str)
-			ax.set_title(f"{value_label_str}s for Month: {filter_month_str}")
+			ax.set_title(f"{value_label_str}s for Month: {filter_moment_str}")
 			plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
 
 			if unique_items:
@@ -164,7 +176,7 @@ def _create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines
 			ax.text(0.5, 0.5, "Please select a filter to display a graph.", ha='center', va='center')
 		ax.figure.canvas.draw_idle()
 
-	combo_month.currentIndexChanged.connect(update_plot)
+	combo_moment.currentIndexChanged.connect(update_plot)
 	combo_category.currentIndexChanged.connect(update_plot)
 	combo_region.currentIndexChanged.connect(update_plot)
 	update_plot()
@@ -213,23 +225,24 @@ def graph_population(data, ax, filter_layout, filter_widgets_list, on_lines_plot
 		for item in filtered_data:
 			key = item['region']
 			if key not in data_to_plot:
-				data_to_plot[key] = {'months': [], 'populations': []}
-			data_to_plot[key]['months'].append(item['month'])
+				data_to_plot[key] = {'moments': [], 'populations': []}
+			data_to_plot[key]['moments'].append(item['moment'])
 			data_to_plot[key]['populations'].append(item['population'])
 
-		ax.set_xlabel("Month")
+		ax.set_xlabel("Time")
+		ax.xaxis.set_major_locator(MaxNLocator(integer=True))
 		ax.set_ylabel("Population")
 		ax.set_title("Population Over Time")
 
 		for name, values in sorted(data_to_plot.items()):
-			if not values['months']: continue
-			sorted_points = sorted(zip(values['months'], values['populations']))
-			months_sorted, pop_sorted = zip(*sorted_points)
-			ax.plot(months_sorted, pop_sorted, marker='o', linestyle='-', label=name, color=next(colors))
+			if not values['moments']: continue
+			sorted_points = sorted(zip(values['moments'], values['populations']))
+			moments_sorted, pop_sorted = zip(*sorted_points)
+			ax.plot(moments_sorted, pop_sorted, marker='o', linestyle='-', label=name, color=next(colors))
 
 		if data_to_plot:
-			min_x = min(min(v['months']) for v in data_to_plot.values() if v['months'])
-			max_x = max(max(v['months']) for v in data_to_plot.values() if v['months'])
+			min_x = min(min(v['moments']) for v in data_to_plot.values() if v['moments'])
+			max_x = max(max(v['moments']) for v in data_to_plot.values() if v['moments'])
 			ax.set_xlim(min_x, max_x)
 
 		if SHOW_LEGEND and data_to_plot:

--- a/tools/plot/chart_library.py
+++ b/tools/plot/chart_library.py
@@ -1,0 +1,282 @@
+from itertools import cycle
+
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+from PyQt6.QtWidgets import QLabel, QComboBox
+
+from tools.plot.custom_widgets import RightClickableComboBox
+from tools.plot.log_parser import parse_data_goods_prices, parse_data_building_types, parse_data_population
+
+FIRST_MONTH = 5 # Makes FIRST_MONTH-1 not have 0 buildings in all regions
+
+STR_ALL_MONTHS = "All months"
+STR_ALL_BUILDINGS = "All buildings"
+STR_ALL_REGIONS = "All regions"
+STR_ALL_GOODS = "All goods"
+
+POS_SUBPLOT_BOTTOM_EDGE = 0.10
+POS_SUBPLOT_RIGHT_EDGE = 0.95
+SHOW_LEGEND = False
+
+# This function will be monkey-patched by the main script
+def get_data(data, str_target):
+	raise NotImplementedError("get_data function was not assigned")
+
+
+def _create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines_plotted, on_plot_cleared, config):
+	"""
+	A generic graphing function that creates a line or bar chart based on a configuration.
+	This function is intended for internal use and is called by specific graph functions.
+	"""
+	all_data = config["parser"](data)
+	fig = ax.figure
+	fig.subplots_adjust(bottom=POS_SUBPLOT_BOTTOM_EDGE, right=POS_SUBPLOT_RIGHT_EDGE)
+
+	# --- Get config values ---
+	category_key = config["category_key"]
+	value_key = config["value_key"]
+	category_label_str = config["category_label"]
+	all_category_str = config["all_category_str"]
+	value_label_str = config["value_label"]
+	add_zero_start = config.get("add_zero_start", False)
+	ComboBoxClass = RightClickableComboBox if config.get("use_right_click_combo", True) else QComboBox
+
+	# --- Create Interactive PyQt Widgets ---
+	lbl_month = QLabel("Month:")
+	combo_month = ComboBoxClass()
+	all_months = sorted(list(set(item['month'] for item in all_data)))
+	combo_month.addItem(STR_ALL_MONTHS)
+	combo_month.addItems([str(m) for m in all_months])
+
+	lbl_category = QLabel(category_label_str)
+	combo_category = ComboBoxClass()
+	all_categories = sorted(list(set(item[category_key] for item in all_data)))
+	combo_category.addItem(all_category_str)
+	combo_category.addItems(all_categories)
+
+	lbl_region = QLabel("Region:")
+	combo_region = ComboBoxClass()
+	all_regions = sorted(list(set(item['region'] for item in all_data)))
+	combo_region.addItem(STR_ALL_REGIONS)
+	combo_region.addItems(all_regions)
+
+	# Add widgets to the layout
+	filter_layout.addWidget(lbl_month, 0, 0)
+	filter_layout.addWidget(combo_month, 0, 1)
+	filter_layout.addWidget(lbl_category, 0, 2)
+	filter_layout.addWidget(combo_category, 0, 3)
+	filter_layout.addWidget(lbl_region, 0, 4)
+	filter_layout.addWidget(combo_region, 0, 5)
+	filter_layout.setColumnStretch(6, 1)
+
+	filter_widgets_list.extend([lbl_month, combo_month, lbl_category, combo_category, lbl_region, combo_region])
+
+	def update_plot():
+		on_plot_cleared()
+		filter_month_str = combo_month.currentText()
+		filter_category_type = combo_category.currentText()
+		filter_region = combo_region.currentText()
+		ax.clear()
+
+		if filter_category_type != all_category_str and filter_region != STR_ALL_REGIONS:
+			ax.text(0.5, 0.5, f"Please select a specific {category_label_str.replace(':', '')} OR a Region, not both.",
+					ha='center', va='center')
+			ax.figure.canvas.draw_idle()
+			return
+
+		filtered_data = [
+			item for item in all_data
+			if (filter_month_str == STR_ALL_MONTHS or item['month'] == int(filter_month_str)) and
+			   (filter_category_type == all_category_str or filter_category_type == item[category_key]) and
+			   (filter_region == STR_ALL_REGIONS or filter_region == item['region'])
+		]
+
+		if not filtered_data:
+			ax.text(0.5, 0.5, "No data matches the current filters.", ha='center', va='center')
+			ax.figure.canvas.draw_idle()
+			return
+
+		is_month_all = filter_month_str == STR_ALL_MONTHS
+		is_category_picked = filter_category_type != all_category_str
+		is_region_picked = filter_region != STR_ALL_REGIONS
+		prop_cycle = plt.rcParams['axes.prop_cycle']
+		colors = cycle(prop_cycle.by_key()['color'])
+
+		# --- Line Graph Logic ---
+		if is_month_all and (is_category_picked or is_region_picked):
+			plot_category_key = category_key if is_region_picked else 'region'
+			data_to_plot = {}
+			for item in filtered_data:
+				key = item[plot_category_key]
+				if key not in data_to_plot:
+					data_to_plot[key] = {'months': [], 'values': []}
+				data_to_plot[key]['months'].append(item['month'])
+				data_to_plot[key]['values'].append(item[value_key])
+
+			if add_zero_start:
+				for _, values in data_to_plot.items():
+					if not values['months']: continue
+					min_month = min(values['months'])
+					if min_month != FIRST_MONTH:
+						values['months'].append(min_month - 1)
+						values['values'].append(0)
+
+			ax.set_xlabel("Month")
+			ax.set_ylabel(value_label_str)
+			title_text = f"{value_label_str}s for: {filter_category_type}" if is_category_picked else f"{value_label_str}s in: {filter_region}"
+			ax.set_title(title_text)
+
+			for name, values in sorted(data_to_plot.items()):
+				if not values['months']: continue
+				sorted_points = sorted(zip(values['months'], values['values']))
+				months_sorted, values_sorted = zip(*sorted_points)
+				ax.plot(months_sorted, values_sorted, marker='o', linestyle='-', label=name, color=next(colors))
+
+			if data_to_plot:
+				min_x = min(min(v['months']) for v in data_to_plot.values() if v['months'])
+				max_x = max(max(v['months']) for v in data_to_plot.values() if v['months'])
+				ax.set_xlim(min_x, max_x)
+
+			if SHOW_LEGEND and data_to_plot:
+				ax.legend(bbox_to_anchor=(1.04, 1), loc="upper left")
+			ax.figure.canvas.draw_idle()
+			on_lines_plotted()
+
+		# --- Bar Graph Logic ---
+		elif not is_month_all and (is_category_picked or is_region_picked):
+			coloring_key = category_key if is_region_picked else 'region'
+			unique_items = sorted(list(set(item[coloring_key] for item in filtered_data)))
+			color_map = {name: next(colors) for name in unique_items}
+			labels = [f"{item[category_key]}\n({item['region']})" for item in filtered_data]
+			values = [item[value_key] for item in filtered_data]
+			bar_colors = [color_map[item[coloring_key]] for item in filtered_data]
+
+			ax.bar(labels, values, color=bar_colors)
+			ax.set_ylabel(value_label_str)
+			ax.set_title(f"{value_label_str}s for Month: {filter_month_str}")
+			plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
+
+			if unique_items:
+				patches = [mpatches.Patch(color=c, label=l) for l, c in color_map.items()]
+				ax.legend(handles=patches, bbox_to_anchor=(1.04, 1), loc="upper left")
+			ax.figure.canvas.draw_idle()
+		else:
+			ax.text(0.5, 0.5, "Please select a filter to display a graph.", ha='center', va='center')
+		ax.figure.canvas.draw_idle()
+
+	combo_month.currentIndexChanged.connect(update_plot)
+	combo_category.currentIndexChanged.connect(update_plot)
+	combo_region.currentIndexChanged.connect(update_plot)
+	update_plot()
+
+
+def graph_population(data, ax, filter_layout, filter_widgets_list, on_lines_plotted, on_plot_cleared):
+	"""Population by Region"""
+	all_pop_data = parse_data_population(data)
+	fig = ax.figure
+	fig.subplots_adjust(bottom=POS_SUBPLOT_BOTTOM_EDGE, right=POS_SUBPLOT_RIGHT_EDGE)
+
+	# --- Create Interactive PyQt Widgets ---
+	lbl_region = QLabel("Region:")
+	combo_region = RightClickableComboBox()
+	all_regions = sorted(list(set(item['region'] for item in all_pop_data)))
+	combo_region.addItem(STR_ALL_REGIONS)
+	combo_region.addItems(all_regions)
+
+	# Add widgets to the layout
+	filter_layout.addWidget(lbl_region, 0, 0)
+	filter_layout.addWidget(combo_region, 0, 1)
+	filter_layout.setColumnStretch(2, 1)
+
+	filter_widgets_list.extend([lbl_region, combo_region])
+
+	def update_plot():
+		on_plot_cleared()
+		filter_region = combo_region.currentText()
+		ax.clear()
+
+		filtered_data = [
+			item for item in all_pop_data
+			if (filter_region == STR_ALL_REGIONS or item['region'] == filter_region)
+		]
+
+		if not filtered_data:
+			ax.text(0.5, 0.5, "No data matches the current filters.", ha='center', va='center')
+			ax.figure.canvas.draw_idle()
+			return
+
+		# --- Plotting Logic ---
+		prop_cycle = plt.rcParams['axes.prop_cycle']
+		colors = cycle(prop_cycle.by_key()['color'])
+
+		data_to_plot = {}
+		for item in filtered_data:
+			key = item['region']
+			if key not in data_to_plot:
+				data_to_plot[key] = {'months': [], 'populations': []}
+			data_to_plot[key]['months'].append(item['month'])
+			data_to_plot[key]['populations'].append(item['population'])
+
+		ax.set_xlabel("Month")
+		ax.set_ylabel("Population")
+		ax.set_title("Population Over Time")
+
+		for name, values in sorted(data_to_plot.items()):
+			if not values['months']: continue
+			sorted_points = sorted(zip(values['months'], values['populations']))
+			months_sorted, pop_sorted = zip(*sorted_points)
+			ax.plot(months_sorted, pop_sorted, marker='o', linestyle='-', label=name, color=next(colors))
+
+		if data_to_plot:
+			min_x = min(min(v['months']) for v in data_to_plot.values() if v['months'])
+			max_x = max(max(v['months']) for v in data_to_plot.values() if v['months'])
+			ax.set_xlim(min_x, max_x)
+
+		if SHOW_LEGEND and data_to_plot:
+			ax.legend(bbox_to_anchor=(1.04, 1), loc="upper left")
+
+		ax.figure.canvas.draw_idle()
+		on_lines_plotted()
+
+	combo_region.currentIndexChanged.connect(update_plot)
+	update_plot()
+
+
+# --- Graph Configurations ---
+
+BT_CONFIG = {
+    "parser": parse_data_building_types,
+    "category_key": "building",
+    "value_key": "count",
+    "category_label": "Building Type:",
+    "all_category_str": STR_ALL_BUILDINGS,
+    "value_label": "Count",
+    "add_zero_start": True,
+    "use_right_click_combo": True
+}
+
+GP_CONFIG = {
+    "parser": parse_data_goods_prices,
+    "category_key": "good",
+    "value_key": "price",
+    "category_label": "Good:",
+    "all_category_str": STR_ALL_GOODS,
+    "value_label": "Price",
+    "add_zero_start": False,
+    "use_right_click_combo": True
+}
+
+# --- Public Graphing Functions ---
+
+def graph_building_types(data, ax, filter_layout, filter_widgets_list, on_lines_plotted, on_plot_cleared):
+	"""Building Types by Region"""
+	_create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines_plotted, on_plot_cleared, config=BT_CONFIG)
+
+def graph_goods_prices(data, ax, filter_layout, filter_widgets_list, on_lines_plotted, on_plot_cleared):
+	"""Goods Prices by Region"""
+	_create_generic_graph(data, ax, filter_layout, filter_widgets_list, on_lines_plotted, on_plot_cleared, config=GP_CONFIG)
+
+
+if __name__ == "__main__":
+	print("This file contains graphing functions and is not meant to be run directly.")
+	print("Please run MT_grapher.py instead.")

--- a/tools/plot/custom_widgets.py
+++ b/tools/plot/custom_widgets.py
@@ -1,0 +1,16 @@
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QComboBox
+
+# --- Custom Widgets ---
+class RightClickableComboBox(QComboBox):
+	"""
+	A custom QComboBox that resets its selection to the first item when right-clicked
+	"""
+	def mousePressEvent(self, event):
+		# Call the parent's event handler to ensure that normal left-clicks and other events are not broken
+		super().mousePressEvent(event)
+
+		# Check if the button that was pressed is the right mouse button
+		if event.button() == Qt.MouseButton.RightButton:
+			# Set the current index to 0 (the "All" option)
+			self.setCurrentIndex(0)

--- a/tools/plot/interactive_tooltip.py
+++ b/tools/plot/interactive_tooltip.py
@@ -156,7 +156,7 @@ class InteractiveLineTooltip:
 
 		# Dynamic positioning with vertical alignment
 		y_min, y_max = self.ax.get_ylim()
-		y_mid = (y_min + y_max) * 0.4
+		y_mid = y_min + (y_max - y_min) * 0.4
 
 		# If cursor is in the top half, place tooltip below the anchor point
 		# The offset will push the text box down
@@ -169,7 +169,7 @@ class InteractiveLineTooltip:
 
 		# Horizontal positioning logic
 		x_min, x_max = self.ax.get_xlim()
-		x_mid = (x_min + x_max) * 0.7
+		x_mid = x_min + (x_max - x_min) * 0.7
 		# If cursor is on the right, align text to the right and use a negative offset
 		if event.xdata > x_mid:
 			self.annot.set_horizontalalignment('right')

--- a/tools/plot/interactive_tooltip.py
+++ b/tools/plot/interactive_tooltip.py
@@ -1,0 +1,225 @@
+import numpy as np
+
+TOOLTIP_PADDING = 20
+TOOLTIP_DISPLAYED_LINES = 25
+LINE_WIDTH_SELECTED = 5
+
+class InteractiveLineTooltip:
+	"""
+	Creates a hover annotation for a Matplotlib axes that shows the
+	Y-values of all lines at the current X-position of the cursor.
+	"""
+
+	def __init__(self, ax):
+		self.ax = ax
+		self.fig = ax.figure
+		print(f"CursorHoverInfo: Initializing for axes: {ax}")
+
+		all_lines = self.ax.get_lines()
+		print(f"CursorHoverInfo: Found {len(all_lines)} total line objects in the axes.")
+
+		# Store original line properties and track the last hovered line
+		self.original_line_widths = {}
+		self.last_hovered_line = None
+
+		# Filter for lines that have a valid label for the legend
+		self.lines = []
+		for line in all_lines:
+			label = line.get_label()
+			if label and not label.startswith('_'):
+				self.lines.append(line)
+				self.original_line_widths[label] = line.get_linewidth()
+
+		self.last_integer_x = None
+		self.closest_line = None
+		self.tooltip_cache = None
+		self.annot = None
+		self.cursor_hover_handler = None
+
+		print(f"CursorHoverInfo: Kept {len(self.lines)} lines with valid labels.")
+
+	def setup_tooltip_handler(self):
+		"""Creates a new tooltip handler for the current axes."""
+		print("\n--- Main window is creating tooltip handler ---")
+
+		# If there are no valid lines, do not set up the hover events
+		if not self.lines:
+			print("CursorHoverInfo: No valid lines found. Tooltip will NOT be activated.")
+			return
+
+		self.tooltip_cache = self.precalculate_tooltips()
+
+		# Create an annotation object, initially invisible
+		self.annot = self.ax.annotate(
+			"",
+			xy=(0, 0),
+			xytext=(15, 15),
+			textcoords="offset points",
+			bbox=dict(boxstyle="round,pad=0.5", fc="white", alpha=0.75),
+			arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0"),
+			fontfamily='monospace',
+		)
+		self.annot.set_visible(False)
+
+		# Connect the event handlers
+		print("CursorHoverInfo: Activating tooltip event handlers.")
+		self.fig.canvas.mpl_connect("motion_notify_event", self.on_hover)
+		self.fig.canvas.mpl_connect("axes_leave_event", self.on_leave)
+
+	def clear_tooltip_handler(self):
+		"""Clears any existing tooltip handler."""
+		self.cursor_hover_handler = None
+
+	def on_hover(self, event):
+		if not hasattr(self, 'annot') or event.inaxes != self.ax or event.xdata is None or event.ydata is None:
+			return
+
+		current_integer_x = int(round(event.xdata))
+		min_vertical_dist = float('inf')
+		closest_line_label = None
+		closest_point_on_line = None
+		current_hovered_line = None
+
+		# Find the closest point on each line to anchor the tooltip arrow
+		for line in self.lines:
+			x_data, y_data = line.get_data()
+
+			# Find the index for the current integer year
+			idx = np.searchsorted(x_data, current_integer_x)
+			if idx < len(x_data) and x_data[idx] == current_integer_x:
+				point_x, point_y = x_data[idx], y_data[idx]
+
+				# Calculate the vertical distance in screen pixels to find the closest line
+				vertical_dist_pixels = abs(self.ax.transData.transform((point_x, point_y))[1] - event.y)
+
+				# Check if this line is the new closest
+				if vertical_dist_pixels < min_vertical_dist:
+					min_vertical_dist = vertical_dist_pixels
+					closest_line_label = line.get_label()
+					closest_point_on_line = (point_x, point_y)
+					current_hovered_line = line
+
+		# Check if the hovered line has changed since the last event
+		if current_hovered_line != self.last_hovered_line:
+			# If there was a previously hovered line, reset its width
+			if self.last_hovered_line is not None:
+				label = self.last_hovered_line.get_label()
+				original_width = self.original_line_widths.get(label)
+				self.last_hovered_line.set_linewidth(original_width)
+
+			# If hovering over a new line
+			if current_hovered_line is not None:
+				current_hovered_line.set_linewidth(LINE_WIDTH_SELECTED)
+
+			# Update the last hovered line and redraw the canvas
+			self.last_hovered_line = current_hovered_line
+			self.fig.canvas.draw_idle()
+
+		if current_integer_x == self.last_integer_x and self.closest_line == closest_line_label:
+			return
+		self.last_integer_x = current_integer_x
+		self.closest_line = closest_line_label
+
+		# Get all data for current X value
+		all_data_for_x = self.tooltip_cache.get(current_integer_x)
+		if not all_data_for_x:
+			if self.annot.get_visible(): self.annot.set_visible(False); self.fig.canvas.draw_idle()
+			return
+
+		# Filter to X closest lines
+		# Calculate each line's vertical distance from the cursor's data coordinate
+		for item in all_data_for_x:
+			item['dist_from_cursor'] = abs(item['y_val'] - event.ydata)
+
+		# Sort by that distance to find the nearest lines
+		all_data_for_x.sort(key=lambda d: d['dist_from_cursor'])
+
+		# Take the X closest and then re-sort them by Y-value for display
+		sorted_data = all_data_for_x[:TOOLTIP_DISPLAYED_LINES]
+		sorted_data.sort(key=lambda d: d['y_val'], reverse=True)
+
+		if not closest_point_on_line:
+			if self.annot.get_visible(): self.annot.set_visible(False); self.fig.canvas.draw_idle()
+			return
+
+		# Build tooltip text
+		x_label = self.ax.get_xlabel() or "X-Value"
+		max_label_len = max(len(d['label']) for d in sorted_data) if sorted_data else 0
+		max_val_len = max(len(f"{d['y_val']:,.2f}") for d in sorted_data) if sorted_data else 0
+
+		info_texts = [f"{x_label:>{max_label_len + 3}} : {current_integer_x}", '']
+		for item in sorted_data:
+			label_str = f"{item['label']:<{max_label_len}}"
+			val_str = f"{item['y_val']:>{max_val_len},.2f}"
+			char_reveal = '*' if item['label'] == closest_line_label else ' '
+			info_texts.append(f"{val_str} : {char_reveal}{label_str}")
+
+		# Dynamic positioning with vertical alignment
+		y_min, y_max = self.ax.get_ylim()
+		y_mid = (y_min + y_max) * 0.4
+
+		# If cursor is in the top half, place tooltip below the anchor point
+		# The offset will push the text box down
+		if event.ydata > y_mid:
+			self.annot.set_verticalalignment('top')
+			vertical_offset = -TOOLTIP_PADDING
+		else:
+			self.annot.set_verticalalignment('bottom')
+			vertical_offset = TOOLTIP_PADDING
+
+		# Horizontal positioning logic
+		x_min, x_max = self.ax.get_xlim()
+		x_mid = (x_min + x_max) * 0.7
+		# If cursor is on the right, align text to the right and use a negative offset
+		if event.xdata > x_mid:
+			self.annot.set_horizontalalignment('right')
+			horizontal_offset = -TOOLTIP_PADDING
+		else:
+			self.annot.set_horizontalalignment('left')
+			horizontal_offset = TOOLTIP_PADDING
+
+		# Set the final combined offset
+		self.annot.xytext = (horizontal_offset, vertical_offset)
+
+		# Update annotation
+		self.annot.set_text("\n".join(info_texts))
+		self.annot.xy = closest_point_on_line
+		self.annot.set_visible(True)
+		self.fig.canvas.draw_idle()
+
+	def on_leave(self, event):
+		if self.last_hovered_line is not None:
+			label = self.last_hovered_line.get_label()
+			original_width = self.original_line_widths.get(label)
+			self.last_hovered_line.set_linewidth(original_width)
+			self.last_hovered_line = None
+			self.fig.canvas.draw_idle()
+
+		if hasattr(self, 'annot') and self.annot.get_visible():
+			self.annot.set_visible(False)
+			self.fig.canvas.draw_idle()
+
+	def precalculate_tooltips(self):
+		"""
+		Processes the plotted lines to create a cache of sorted data for every year, to avoid recalculating data on every mouse movement
+		"""
+		print("CursorHoverInfo: Pre-calculating tooltip data... ", end="")
+		cache = {}
+		if not self.lines: return {}
+		all_x_data = np.concatenate([line.get_xdata() for line in self.lines])
+		if all_x_data.size == 0:
+			print("No data points found.")
+			return {}
+		min_x, max_x = int(np.min(all_x_data)), int(np.max(all_x_data))
+		for x_val in range(min_x, max_x + 1):
+			x_val_data = []
+			for line in self.lines:
+				x_data, y_data = line.get_data()
+				idx = np.searchsorted(x_data, x_val)
+				if idx < len(x_data) and x_data[idx] == x_val:
+					x_val_data.append({'label': line.get_label(), 'y_val': y_data[idx]})
+			if x_val_data:
+				x_val_data.sort(key=lambda item: item['y_val'], reverse=True)
+				cache[x_val] = x_val_data
+		print("Done.")
+		return cache

--- a/tools/plot/log_parser.py
+++ b/tools/plot/log_parser.py
@@ -1,0 +1,96 @@
+import re
+
+bt_data_cache = None
+gp_data_cache = None
+pop_data_cache = None
+
+def parse_data_building_types(data):
+	"""
+	Parses all building type lines from the log data.
+	Uses a cache to avoid reparsing the same data.
+	"""
+	global bt_data_cache
+	if bt_data_cache is not None:
+		return bt_data_cache
+
+	print("Parsing building data for the first time...")
+	pattern = re.compile(r"::BT:(\d+):(.*?):(\d+):(.*)")
+	parsed_data = [
+		{"month": int(m.group(1)), "building": m.group(2).strip(),
+		 "count": int(m.group(3)), "region": m.group(4).strip()}
+		for m in pattern.finditer(data)
+	]
+	bt_data_cache = parsed_data
+	print(f"Found and cached {len(bt_data_cache)} building entries.")
+	return parsed_data
+
+
+def parse_data_goods_prices(data):
+	"""
+	Parses all goods price (::GP::) lines from the log data.
+	Uses a cache to avoid reparsing the same data.
+	"""
+	global gp_data_cache
+	if gp_data_cache is not None:
+		return gp_data_cache
+
+	print("Parsing goods price data for the first time...")
+	# Regex to capture: 1:Month, 2:Good, 3:Region, 4:Price
+	pattern = re.compile(r"::GP::(\d+):(.+?):(.+?):([\d.-]+)")
+
+	parsed_data = []
+	for m in pattern.finditer(data):
+		region_name = m.group(3).strip()
+
+		if 'Ocean' in region_name:
+			continue
+
+		parsed_data.append({
+			"month": int(m.group(1)),
+			"good": m.group(2).strip(),
+			"region": region_name,
+			"price": float(m.group(4))
+		})
+
+	gp_data_cache = parsed_data
+	print(f"Found and cached {len(gp_data_cache)} goods price entries (oceans excluded).")
+	return parsed_data
+
+
+def _parse_population_value(value_str):
+	"""Converts a population string (e.g., '2.2M', '75K', '1,234') to an integer."""
+	value_str = value_str.strip().replace(',', '')
+	if 'M' in value_str:
+		return int(float(value_str.replace('M', '')) * 1_000_000)
+	if 'K' in value_str:
+		return int(float(value_str.replace('K', '')) * 1_000)
+	return int(value_str)
+
+def parse_data_population(data):
+	"""
+	Parses all population (::POP::) lines from the log data.
+	Uses a cache to avoid reparsing the same data.
+	"""
+	global pop_data_cache
+	if pop_data_cache is not None:
+		return pop_data_cache
+
+	print("Parsing population data for the first time...")
+	# Regex to capture: 1:Month, 2:Region, 3:Population String
+	pattern = re.compile(r"::POP::(\d+):(.+?):([\d.,MK]+)")
+
+	parsed_data = []
+	for m in pattern.finditer(data):
+		try:
+			population_value = _parse_population_value(m.group(3))
+			parsed_data.append({
+				"month": int(m.group(1)),
+				"region": m.group(2).strip(),
+				"population": population_value
+			})
+		except (ValueError, IndexError) as e:
+			print(f"Warning: Could not parse population line: '{m.group(0)}'. Error: {e}")
+
+	pop_data_cache = parsed_data
+	print(f"Found and cached {len(pop_data_cache)} population entries.")
+	return parsed_data

--- a/tools/plot/log_parser.py
+++ b/tools/plot/log_parser.py
@@ -16,7 +16,7 @@ def parse_data_building_types(data):
 	print("Parsing building data for the first time...")
 	pattern = re.compile(r"::BT:(\d+):(.*?):(\d+):(.*)")
 	parsed_data = [
-		{"month": int(m.group(1)), "building": m.group(2).strip(),
+		{"moment": int(m.group(1)), "building": m.group(2).strip(),
 		 "count": int(m.group(3)), "region": m.group(4).strip()}
 		for m in pattern.finditer(data)
 	]
@@ -35,7 +35,7 @@ def parse_data_goods_prices(data):
 		return gp_data_cache
 
 	print("Parsing goods price data for the first time...")
-	# Regex to capture: 1:Month, 2:Good, 3:Region, 4:Price
+	# Regex to capture: 1:Moment, 2:Good, 3:Region, 4:Price
 	pattern = re.compile(r"::GP::(\d+):(.+?):(.+?):([\d.-]+)")
 
 	parsed_data = []
@@ -46,7 +46,7 @@ def parse_data_goods_prices(data):
 			continue
 
 		parsed_data.append({
-			"month": int(m.group(1)),
+			"moment": int(m.group(1)),
 			"good": m.group(2).strip(),
 			"region": region_name,
 			"price": float(m.group(4))
@@ -76,7 +76,7 @@ def parse_data_population(data):
 		return pop_data_cache
 
 	print("Parsing population data for the first time...")
-	# Regex to capture: 1:Month, 2:Region, 3:Population String
+	# Regex to capture: 1:Moment, 2:Region, 3:Population String
 	pattern = re.compile(r"::POP::(\d+):(.+?):([\d.,MK]+)")
 
 	parsed_data = []
@@ -84,7 +84,7 @@ def parse_data_population(data):
 		try:
 			population_value = _parse_population_value(m.group(3))
 			parsed_data.append({
-				"month": int(m.group(1)),
+				"moment": int(m.group(1)),
 				"region": m.group(2).strip(),
 				"population": population_value
 			})


### PR DESCRIPTION
To enable plotting, in April 1337, run in console: 
`event LOGGER_CHARTS.04`

When satisfied, run MT_grapher.py & follow the short instructions (assigning the path to the log folder)

There is always a month filter & a region filter. Sometimes there is a 3rd one.

There are 2 types of charts, based on the selected filters:
- If month filter is chosen, then there will be plotted a bar chart.
- Otherwise, it will be a line chart.

Tooltip is displayed, showing the 20 closest lines to the cursor (it wouldn't fit in the tooltip otherwise)
Hovered line is thickened for emphasis

Hotkeys:
- Press ` (backquote) to open table of the 3 charts with their corresponding hotkey
- When chart table is closed (e.g. when the app is started), the hotkeys (e.g. 1, 2, 3) can be pressed any time to switch between charts.
- Can press tab to quickly jump between UI elements
- When combobox is selected, can press up/down to quickly navigate between filters (e.g. months, regions, goods, building types)
- Can press right-click on combobox to reset filter
- Press F11 for full-screen