### PR TITLE
Mepper branch merge; see desc for changes

### DIFF
--- a/main_menu/common/static_modifiers/MnT_integration.txt
+++ b/main_menu/common/static_modifiers/MnT_integration.txt
@@ -1,0 +1,9 @@
+REPLACE:integration_core = {
+	game_data = {
+		category = location
+	}
+	local_monthly_control = 0.001
+	local_max_control = 0.20
+	#growth_is_primary_culture = yes			Mepper commented out: growth only primary culture because a core just makes no sense
+	owner_gets_vision_when_occupied = yes
+}

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,1 @@
+Add readme contents here

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,3 @@
-Add readme contents here
+MEIOU and Taxes
+
+Overhaul mod to be. Restart of M&T for EU4. 


### PR DESCRIPTION
- Don't let new born pops all be primary culture in cores, that just makes no sense. In vanilla it would automatically let _all_ babies in cores be of primary culture. Historically and realistically this is ridiculous, that is not how this works. 
- Add a readme.md in the main folder, extremely barebones but once we have more of the mod in place we can expand it to a nice readme