### PR TITLE
Stopgap Measures for two (imo) severe vanilla problems

### DIFF
--- a/in_game/common/auto_modifiers/MnT_pop_demote_fix.txt
+++ b/in_game/common/auto_modifiers/MnT_pop_demote_fix.txt
@@ -1,0 +1,71 @@
+﻿# Country demotion sync: base value 1, we’ll multiply it in script
+
+mod_country_pop_demotion_flat = {
+	category = country
+	type = country
+	
+	potential_trigger = {
+		modifier:global_pop_promotion_speed > 0
+	}		
+	
+	scales_with = {
+		value = modifier:global_pop_promotion_speed
+		multiply = 2
+		min = 0
+	}
+
+    global_pop_demotion_speed = 1
+}
+
+mod_country_pop_demotion_perc = {
+	category = country
+	type = country
+	
+	potential_trigger = {
+		modifier:global_pop_promotion_speed_modifier > 0
+	}		
+	
+	scales_with = {
+		value = modifier:global_pop_promotion_speed_modifier
+		multiply = 2
+		min = 0
+	}
+
+    global_pop_demotion_speed_modifier = 1
+}
+
+# Location demotion sync: same deal for local scope
+
+mod_local_pop_demotion_flat = {
+	category = location
+	type = location
+	
+	potential_trigger = {
+		modifier:local_pop_promotion_speed > 0
+	}		
+	
+	scales_with = {
+		value = modifier:local_pop_promotion_speed
+		multiply = 2
+		min = 0
+	}
+
+    local_pop_demotion_speed = 1
+}
+
+mod_local_pop_demotion_perc = {
+	category = location
+	type = location
+	
+	potential_trigger = {
+		modifier:local_pop_promotion_speed_modifier > 0
+	}		
+	
+	scales_with = {
+		value = modifier:local_pop_promotion_speed_modifier
+		multiply = 2
+		min = 0
+	}
+
+    local_pop_demotion_speed_modifier = 1
+}

--- a/main_menu/common/game_concepts/MnT_game_concepts.txt
+++ b/main_menu/common/game_concepts/MnT_game_concepts.txt
@@ -1,0 +1,3 @@
+﻿pop_demote_fix = {
+	texture = "gfx/interface/icons/location_icons/demotion.dds"
+}

--- a/main_menu/common/static_modifiers/MnT_location.txt
+++ b/main_menu/common/static_modifiers/MnT_location.txt
@@ -15,3 +15,17 @@ REPLACE:inverse_control = {
 	local_sailors_modifier = -1.0
 
 }
+
+
+
+REPLACE:total_population = {
+	game_data = {
+		category = location
+	}
+	supply_limit = 0.02
+	blockade_force_required = 0.02
+	
+	local_max_rgo_size = 0.025
+	
+	free_building_levels = 0.5  #molkemon: give 0,5 building levels per 1k pops instead of 0,5 per 100k pops. This is almost certainly the originally intended behaviour and someone at pdx just forgot that total_population counts pops in thousands. the other values are sane
+}

--- a/main_menu/localization/english/MnT_pop_demote_fix_l_english.yml
+++ b/main_menu/localization/english/MnT_pop_demote_fix_l_english.yml
@@ -1,0 +1,10 @@
+﻿l_english:
+ game_concept_pop_demote_fix: "Social Mobility Goes Both Ways"
+ game_concept_pop_demote_fix_desc: "As opportunities for social mobility expand, so too grows the risk of losing one’s hard-won position. When many strive to rise, those already at the top become ever more replaceable."    
+    
+ AUTO_MODIFIER_NAME_mod_country_pop_demotion_flat: "[pop_demote_fix|e]"
+ AUTO_MODIFIER_NAME_mod_country_pop_demotion_perc: "[pop_demote_fix|e]"
+ AUTO_MODIFIER_NAME_mod_local_pop_demotion_flat: "[pop_demote_fix|e]"
+ AUTO_MODIFIER_NAME_mod_local_pop_demotion_perc: "[pop_demote_fix|e]"
+ 
+ 


### PR DESCRIPTION
Hello,

so after playing through an entire Netherlands campaign up to currently 1754 mostly on speed 3 and paying very close attention to what was happening at any given time, I have ran into two issues that imo need immediate fixing, even though my changes are at best a stopgap measure until something better can devised. 

Both issues are probably less notable when playing wide, but I played very tall, staying in the low countries exclusively and never colonizing and those 2 problems basically break the game if you play this way.

---

**Issue 1: Building Cap increase from population is too low**

If you look at the Building Cap tooltip you will see that population is supposed to give increased build cap, but it will at best say 0 or 1 for you. That is because currently you get 0,5 building cap increase per 100k population. This clearly cannot be the intended value, it is highly likely someone at paradox didn't get the memo that the Total_Population location modifier works in 1000s, not in single pops.

I have adjusted the value to give 0,5 building cap for 1k pop now which is almost certainly the originally intended value and I expect paradox themselfs to patch this soon. After playing for centuries with this, it seems still fairly balanced as you will still fairly quickly run out of free building cap and have to shell out extra for building larger cities. 


---


**Issue 2: Pop Demotion Speed is way too slow and will cripple a highly developed country in the last age**

So you have probably seen those fancy techs that give pop promotion speed, which is nice, as you need your peasants to grow strong and wealthy quickly so your newly constructed burgher buildings don't stand around empty. This is great.

However, in the last age when you basically industrialize your country, all those burgher buildings get upgraded to buildings for laborers and it is absolutely horrible! If your cities do not have a large surplus of peasants randomly left, which they almost certainly won't if you play somewhat tall, all those upgraded t4 factories will remain empty for DECADES. Because you don't have peasants that can promote, and more critically, your Burghers are now just sitting around doing FUCK ALL while refusing to demote at any reasonable rate. 

That is because the default pop demotion speed seems to be 100 per month, and you will basically never have modifiers that increase that. The only things I found that increase it for vanilla are some disasters and bankruptcy.
In large cities (80k population plus) this can mean that your burghers will take several DECADES to demote to laborers and you can literally do nothing about it. Even if you don't upgrade to t4 buildings, your estates will do it for you! This is clearly not realistic or acceptable. 


My solution to this is add an auto modifier that sums every country and location pop promotion modifier, both percentage based and flat, DOUBLES it and then applies those values to every countries and locations pop demote speed modifiers (again, both flat and percentage based). The reason for doubling it is because IRL it is clearly much easier to become a hobo than to become a noble lord. 

With 184% promotion speed this then comes to 368% demotion speed, at which rate you can demote about 470 pops per month. It's still a bit slow imo when you think about how catastrophic the industrial revolution was for many artisans, but it will do for now. I'm open to balance this further and throw it out once we can come up with something better.


I even made a shiny tooltip for the auto-modifier about it that you can awe at in the ledger: 


<img width="771" height="680" alt="image" src="https://github.com/user-attachments/assets/d36c0892-960a-41b7-a999-b56db3209300" />

I also expect paradox to fix this sooner or later, but as it is a late game, tall builds only problem it might take them a little as there probably won't be as many complaints. 