### PR TITLE
Add game_id in metadata, for Jetbrains plugin Paradox Language Support

### DIFF
--- a/.metadata/metadata.json
+++ b/.metadata/metadata.json
@@ -2,6 +2,7 @@
   "name" : "MEIOU and Taxes",
   "id" : "mnt",
   "version" : "1.0",
+  "game_id" : "eu5",
   "supported_game_version" : "1.0.*",
   "short_description" : "Overhaul in the works",
   "picture" : "thumbnail.png",


### PR DESCRIPTION
So that the mod is correctly associated with EU5 by the plugin, for the linter to work in Jetbrains