### PR TITLE
Make cost of the court generate market demand

### DIFF
--- a/in_game/common/goods_demand/MnT_cost_of_the_court.txt
+++ b/in_game/common/goods_demand/MnT_cost_of_the_court.txt
@@ -1,0 +1,11 @@
+﻿# Based on "royal_court" building, without goods_gold, marble and books
+# Since those tend to have much limited supply
+
+cost_of_the_court = {	# Total 40
+	furniture = 3 		# 9
+	tools = 1			# 3
+	glass = 2			# 4
+	fine_cloth = 4 		# 24
+
+	category = government_activities
+}

--- a/in_game/common/on_action/MnT_cost_of_the_court.txt
+++ b/in_game/common/on_action/MnT_cost_of_the_court.txt
@@ -1,0 +1,5 @@
+monthly_country_pulse = {
+	events = {
+		cost_of_the_court.1
+	}
+}

--- a/in_game/events/MnT_cost_of_the_court.txt
+++ b/in_game/events/MnT_cost_of_the_court.txt
@@ -1,0 +1,22 @@
+namespace = cost_of_the_court
+
+# Recalculate demands from cost of the court
+cost_of_the_court.1 = {
+	type = country_event
+	hidden = yes
+	immediate = {
+		capital.market = {
+			add_temporary_demand = {
+				type = demand:cost_of_the_court
+				months = 1
+				scale = {
+					value = "root.court_maintenance"
+					multiply = "root.modifier:court_spending_cost"
+					multiply = "root.country_tax_base"
+					divide = 40 # Default price for this demand at scale 1
+				}
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
<img width="718" height="476" alt="image" src="https://github.com/user-attachments/assets/2cff4a28-0c9b-49a0-9d85-f20700df5e92" />

A common complaint about the current tax base system and income calculation is that increasing tax base (by expanding trade) might lead to faster growth in state spending than income generation, leading to a net loss. This loss is not just a financial loss; rather, it represents a genuine leakage of money from the economy. I attempt to fix this by implementing a mechanic where the money spent on the cost of the court will generate actual market demands. This means that: 1) There's now an explanation of where the money goes when you spend it on the court, enhancing realism and immersion 2) Increasing the cost of the court will increase market demand and enhancing the profitability of industries, making it no longer a net loss for the player.

The implementation now is very simple: I added a monthly country pulse that generate a temporary demand (modeled after the demand of Royal Court building, without books, gold and marble, since they tend to have limited supply) that lasts one month. The demand size is calculated using the default price rather than current price to make calculation easier. For now, the demand is generated at the market where the capital is located.

There are, however, issues that I'm unable to solve, and I would love to get some feedback:
1. Creating temporary demands that last only for a month seems to mess up with the some tooltips. Even though only one temporary demand is actually applied, some tooltips would suggest that there are two such demands.
2. Since each country will generate its own cost of the court demand, markets with a lot of countries' capitals will see their temporary demand tooltip spammed with this.

Ideally, we want a mechanism to aggregate all such demands within a market, but I'm not sure how we can achieve that.
