### PR TITLE
Two mapmodes modified

### DIFF
--- a/in_game/gfx/map/map_modes/mnt_map_modes.txt
+++ b/in_game/gfx/map/map_modes/mnt_map_modes.txt
@@ -266,3 +266,69 @@ REPLACE:rivers = {
 		after_lighting_blend =		@data_after_lighting_blend
 	}
 }
+
+market_access = {
+	map_color = {	
+	 	if = {
+	 		limit = {
+	 			has_owner = yes
+	 		}
+			lerp = {
+				min_color = define:NMapColors|MAP_COLOR_LOW
+				max_color = define:NMapColors|MAP_COLOR_HIGH
+
+				factor = {
+					value = market_access
+					subtract = 0.5
+					multiply = 2
+				}
+			}
+		}
+	}
+
+	tooltip_key = {
+
+	}
+	
+	small_map_names = location
+	medium_map_names = market
+	large_map_names = market
+
+	small_tooltip_context = location
+	medium_tooltip_context = market
+	large_tooltip_context = market
+	enable_rivers = yes
+
+	flatmap_behaviour = Always
+	use_fow = no
+
+	category = economy
+	index = 3
+
+	map_markers = {
+		all = no
+		market_marker = yes
+		toll_marker = yes
+	}
+	
+	gradient_parameters = {
+		zoom_step = @zoom_step_near
+
+		gradient_alpha_inside = 	@data_gradient_alpha_inside
+		gradient_alpha_outside = 	@data_gradient_alpha_outside
+		gradient_width = 			@data_gradient_width
+		gradient_color_mult =		@data_gradient_color_mult
+		edge_width = 				@data_edge_width
+		edge_sharpness = 			@data_edge_sharpness
+		edge_alpha = 				@data_edge_alpha
+		edge_color_mult = 			@data_edge_color_mult
+		before_lighting_blend =		@data_before_lighting_blend
+		after_lighting_blend =		@data_after_lighting_blend
+	}
+	
+	refresh_colors_on_selection_change = yes
+	color_refresh_counters = { Month }
+	color_and_names_refresh_counters = { MarketReach LocationOwnerChanged }
+	map_lines_mode = ToMarketCenter
+}
+

--- a/in_game/gfx/map/map_modes/mnt_map_modes.txt
+++ b/in_game/gfx/map/map_modes/mnt_map_modes.txt
@@ -332,3 +332,84 @@ market_access = {
 	map_lines_mode = ToMarketCenter
 }
 
+REPLACE:stability = {
+	map_color = {
+		if = {
+			limit = {
+				has_owner = yes
+			}
+			lerp = {
+				min_color = define:NMapColors|MAP_COLOR_LOW
+				max_color = define:NMapColors|MAP_COLOR_HIGH
+				factor = {
+					value = owner.stability
+					add = 25 # everything below -25 is red
+					divide = 75 # everything above +50 is green
+				}
+			}
+		}
+	}
+	tooltip_key = {
+	}
+	
+	small_map_names = location
+	medium_map_names = country
+	large_map_names = country
+
+	small_tooltip_context = country
+	medium_tooltip_context = country
+	large_tooltip_context = country
+
+	flatmap_behaviour = Always
+	use_fow = no
+
+	category = government
+	index = 3
+
+	gradient_parameters = {
+		zoom_step = @zoom_step_near
+
+		gradient_alpha_inside = 	@data_gradient_alpha_inside
+		gradient_alpha_outside = 	@data_gradient_alpha_outside
+		gradient_width = 			@data_gradient_width
+		gradient_color_mult =		@data_gradient_color_mult
+		edge_width = 				@data_edge_width
+		edge_sharpness = 			@data_edge_sharpness
+		edge_alpha = 				@data_edge_alpha
+		edge_color_mult = 			@data_edge_color_mult
+		before_lighting_blend =		@data_before_lighting_blend
+		after_lighting_blend =		@data_after_lighting_blend
+	}
+	
+		flatmap_gradient_parameters = {
+		zoom_step = @zoom_step_flatmap
+
+		gradient_alpha_inside = 	@flatmap_gradient_alpha_inside
+		gradient_alpha_outside = 	@flatmap_gradient_alpha_outside
+		gradient_width = 			@flatmap_gradient_width
+		gradient_color_mult =		@flatmap_gradient_color_mult
+		edge_width = 				@flatmap_edge_width
+		edge_sharpness = 			@flatmap_edge_sharpness
+		edge_alpha = 				@flatmap_edge_alpha
+		edge_color_mult = 			@flatmap_edge_color_mult
+		before_lighting_blend =		@flatmap_before_lighting_blend
+		after_lighting_blend =		@flatmap_after_lighting_blend
+	}
+	flatmap_gradient_parameters = {
+		zoom_step = @zoom_step_flatmap_far
+
+		gradient_alpha_inside = 	@flatmap_far_gradient_alpha_inside
+		gradient_alpha_outside = 	@flatmap_far_gradient_alpha_outside
+		gradient_width = 			@flatmap_far_gradient_width 
+		gradient_color_mult =		@flatmap_far_gradient_color_mult 
+		edge_width = 				@flatmap_far_edge_width 		
+		edge_sharpness = 			@flatmap_far_edge_sharpness 	
+		edge_alpha = 				@flatmap_far_edge_alpha 	
+		edge_color_mult = 			@flatmap_far_edge_color_mult 
+		before_lighting_blend =		@flatmap_far_before_lighting_blend 
+		after_lighting_blend =		@flatmap_far_after_lighting_blend 
+	}
+	
+	refresh_colors_on_selection_change = yes
+	color_refresh_counters = { Day }
+}

--- a/main_menu/localization/english/mnt_interfaces_l_english.yml
+++ b/main_menu/localization/english/mnt_interfaces_l_english.yml
@@ -6,3 +6,6 @@
 
  mapmode_max_tax_base_global_name: "Potential Tax Base (Global)"
  MAPMODE_MAX_TAX_BASE_GLOBAL: "#T $mapmode_tax_base_name$#!\n$mapmode_common_start$ their [owner|e]'s potential [tax_base|e]. Note: value is still 0 for provinces with 0 control."
+
+ mapmode_market_access_name: "Market Access"
+ MAPMODE_MARKET_ACCESS: "#T $mapmode_market_access_name$#!\n$mapmode_common_start$ their [market_access|e]."


### PR DESCRIPTION
New mapmode for market access, showing markets, tolls and trade routes with locations colored by their market access as a background:
<img width="1121" height="1147" alt="image" src="https://github.com/user-attachments/assets/961aa90a-63cc-418b-8792-7f653c703266" />

Modified stability mapmode which was not working well in vanilla. This one has everyone <-25 stab in red, >+50 in green and colors everything in between on gradient. Tooltips inform about stability.
<img width="1245" height="1184" alt="image" src="https://github.com/user-attachments/assets/81162657-197c-462c-93b5-796bd1dcee9e" />
