### PR TITLE
Remove complaints in log files about the logger events' lack of description & title

### DIFF
--- a/in_game/events/SYS-CENSUS.txt
+++ b/in_game/events/SYS-CENSUS.txt
@@ -5,6 +5,7 @@
 # Force writting another chunk
 LOGGER_CHARTS.01 = {
     hidden = yes
+	orphan = yes
     immediate = {
         debug_log = ""
     }
@@ -14,6 +15,7 @@ LOGGER_CHARTS.01 = {
 LOGGER_CHARTS.02 = {
     type = country_event
     hidden = yes
+	orphan = yes
     immediate = {
 		change_global_variable = { name = month add = 1 }
         run_logging = yes
@@ -24,6 +26,7 @@ LOGGER_CHARTS.02 = {
 LOGGER_CHARTS.03 = {
     type = country_event
     hidden = yes
+	orphan = yes
     immediate = {
         set_global_variable = { name = month value = 4 }
         run_logging = yes
@@ -34,6 +37,7 @@ LOGGER_CHARTS.03 = {
 LOGGER_CHARTS.04 = {
 	type = country_event
 	hidden = yes
+	orphan = yes
 	immediate = {
 		set_global_variable = is_logging_enabled
 	}
@@ -43,6 +47,7 @@ LOGGER_CHARTS.04 = {
 LOGGER_CHARTS.05 = {
 	type = country_event
 	hidden = yes
+	orphan = yes
 	immediate = {
 		remove_global_variable = is_logging_enabled
 	}


### PR DESCRIPTION
Closes #61 

Adds `orphan = yes` to all logger events