### PR TITLE
feat(economy): Transfer estates wealth on annexation, vassal integration and location ownership change

### DIFF
--- a/in_game/common/on_action/MnT_hardcoded.txt
+++ b/in_game/common/on_action/MnT_hardcoded.txt
@@ -1,9 +1,12 @@
 # A crude heuristic before we have proper location level wealth tracking
 # Calculate the share of potential tax base of the losing side's locations
-# Then, transfer that percentage of the losing side's estate
-# When the winning side does not have that estate, transfer it to the treasury
+# Then, transfer that percentage of the losing side's estate to the winner's corresponding ones
+# When the winning side does not have that estate, transfer it to their treasury
 # It's not very refined, just a first step to solve the economic leakage
 
+# When a peace is signed, the order of execution is
+# on_pre_losing_war => on_took_location_in_peace_treaty => on_losing_war
+# Both on_pre_losing_war and on_losing_war seems to be triggered twice though
 
 on_pre_losing_war = {
     on_actions = {
@@ -77,6 +80,12 @@ MnT_on_pre_losing_war = {
             set_variable = {
                 name = estate_cossacks_war_lost
                 value = 0
+            }
+            # My testing suggests that on_losing_war is always executed twice
+            # We need to ensure that we don't transfer wealth twice
+            set_variable = {
+                name = on_losing_war_not_triggered
+                value = 1
             }
         }
     }
@@ -210,7 +219,15 @@ MnT_took_location_in_peace_treaty = {
 }
 
 MnT_on_losing_war = {
+    trigger = {
+        scope:loser = {
+            has_variable = on_losing_war_not_triggered
+        }
+    }
     effect = {
+        scope:loser = {
+            remove_variable = on_losing_war_not_triggered
+        }
         scope:winner= {
             if = {
                 limit = {

--- a/in_game/common/on_action/MnT_hardcoded.txt
+++ b/in_game/common/on_action/MnT_hardcoded.txt
@@ -1,0 +1,374 @@
+# A crude heuristic before we have proper location level wealth tracking
+# Calculate the share of potential tax base of the losing side's locations
+# Then, transfer that percentage of the losing side's estate
+# When the winning side does not have that estate, transfer it to the treasury
+# It's not very refined, just a first step to solve the economic leakage
+
+
+on_pre_losing_war = {
+    on_actions = {
+        MnT_on_pre_losing_war
+    }
+}
+
+on_took_location_in_peace_treaty = {
+    on_actions = {
+        MnT_took_location_in_peace_treaty
+    }
+}
+
+on_losing_war = {
+    on_actions = {
+        MnT_on_losing_war
+    }
+}
+
+
+MnT_on_pre_losing_war = {
+    effect = {
+        scope:loser = {
+            set_local_variable = {
+                name = total_potential_tax_base
+                value = 0
+            }
+            every_owned_location = {
+                limit = { local_control > 0 }
+                set_variable = {
+                    name = potential_tax_base
+                    value = {
+                        value = location_tax_base
+                        divide = local_control
+                    }
+                }
+                change_local_variable = {
+                    name = total_potential_tax_base
+                    add = var:potential_tax_base
+                }
+
+            }
+            set_variable = {
+                name = total_potential_tax_base
+                value = local_var:total_potential_tax_base
+            }
+            set_variable = {
+                name = estate_nobles_war_lost
+                value = 0
+            }
+            set_variable = {
+                name = estate_burghers_war_lost
+                value = 0
+            }
+            set_variable = {
+                name = estate_clergy_war_lost
+                value = 0
+            }
+            set_variable = {
+                name = estate_peasants_war_lost
+                value = 0
+            }
+            set_variable = {
+                name = estate_tribes_war_lost
+                value = 0
+            }
+            set_variable = {
+                name = estate_dhimmi_war_lost
+                value = 0
+            }
+            set_variable = {
+                name = estate_cossacks_war_lost
+                value = 0
+            }
+        }
+    }
+}
+
+MnT_took_location_in_peace_treaty = {
+    effect = {
+        scope:location = {
+            set_local_variable = {
+                # Proportion of total national estates wealth to be transferred because of this location
+                name = local_tax_base_share
+                value = {
+                    value = var:potential_tax_base
+                    divide = scope:loser.var:total_potential_tax_base
+                }
+            }
+            if = {
+                limit = {
+                    scope:loser = {
+                        country_has_estate = estate_type:nobles_estate
+                    }
+                }
+                scope:loser = {
+                    change_variable = {
+                        name = estate_nobles_war_lost
+                        add = {
+                            value = "estate(estate_type:nobles_estate).estate_gold"
+                            multiply = local_var:local_tax_base_share
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    scope:loser = {
+                        country_has_estate = estate_type:burghers_estate
+                    }
+                }
+                scope:loser = {
+                    change_variable = {
+                        name = estate_burghers_war_lost
+                        add = {
+                            value = "estate(estate_type:burghers_estate).estate_gold"
+                            multiply = local_var:local_tax_base_share
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    scope:loser = {
+                        country_has_estate = estate_type:clergy_estate
+                    }
+                }
+                scope:loser = {
+                    change_variable = {
+                        name = estate_clergy_war_lost
+                        add = {
+                            value = "estate(estate_type:clergy_estate).estate_gold"
+                            multiply = local_var:local_tax_base_share
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    scope:loser = {
+                        country_has_estate = estate_type:peasants_estate
+                    }
+                }
+                scope:loser = {
+                    change_variable = {
+                        name = estate_peasants_war_lost
+                        add = {
+                            value = "estate(estate_type:peasants_estate).estate_gold"
+                            multiply = local_var:local_tax_base_share
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    scope:loser = {
+                        country_has_estate = estate_type:tribes_estate
+                    }
+                }
+                scope:loser = {
+                    change_variable = {
+                        name = estate_tribes_war_lost
+                        add = {
+                            value = "estate(estate_type:tribes_estate).estate_gold"
+                            multiply = local_var:local_tax_base_share
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    scope:loser = {
+                        country_has_estate = estate_type:dhimmi_estate
+                    }
+                }
+                scope:loser = {
+                    change_variable = {
+                        name = estate_dhimmi_war_lost
+                        add = {
+                            value = "estate(estate_type:dhimmi_estate).estate_gold"
+                            multiply = local_var:local_tax_base_share
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    scope:loser = {
+                        country_has_estate = estate_type:cossacks_estate
+                    }
+                }
+                scope:loser = {
+                    change_variable = {
+                        name = estate_cossacks_war_lost
+                        add = {
+                            value = "estate(estate_type:cossacks_estate).estate_gold"
+                            multiply = local_var:local_tax_base_share
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+MnT_on_losing_war = {
+    effect = {
+        scope:winner= {
+            if = {
+                limit = {
+                    country_has_estate = estate_type:nobles_estate
+                }
+                "estate(estate_type:nobles_estate)" = {
+                    estate_add_gold = {
+                        value = scope:loser.var:estate_nobles_war_lost
+                    }
+                }
+            } else = {
+                add_gold = {
+                    value = scope:loser.var:estate_nobles_war_lost
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:burghers_estate
+                }
+                "estate(estate_type:burghers_estate)" = {
+                    estate_add_gold = {
+                        value = scope:loser.var:estate_burghers_war_lost
+                    }
+                }
+            } else = {
+                add_gold = {
+                    value = scope:loser.var:estate_burghers_war_lost
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:clergy_estate
+                }
+                "estate(estate_type:clergy_estate)" = {
+                    estate_add_gold = {
+                        value = scope:loser.var:estate_clergy_war_lost
+                    }
+                }
+            } else = {
+                add_gold = {
+                    value = scope:loser.var:estate_clergy_war_lost
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:peasants_estate
+                }
+                "estate(estate_type:peasants_estate)" = {
+                    estate_add_gold = {
+                        value = scope:loser.var:estate_peasants_war_lost
+                    }
+                }
+            } else = {
+                add_gold = {
+                    value = scope:loser.var:estate_peasants_war_lost
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:tribes_estate
+                }
+                "estate(estate_type:tribes_estate)" = {
+                    estate_add_gold = {
+                        value = scope:loser.var:estate_tribes_war_lost
+                    }
+                }
+            } else = {
+                add_gold = {
+                    value = scope:loser.var:estate_tribes_war_lost
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:dhimmi_estate
+                }
+                "estate(estate_type:dhimmi_estate)" = {
+                    estate_add_gold = {
+                        value = scope:loser.var:estate_dhimmi_war_lost
+                    }
+                }
+            } else = {
+                add_gold = {
+                    value = scope:loser.var:estate_dhimmi_war_lost
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:cossacks_estate
+                }
+                "estate(estate_type:cossacks_estate)" = {
+                    estate_add_gold = {
+                        value = scope:loser.var:estate_cossacks_war_lost
+                    }
+                }
+            } else = {
+                add_gold = {
+                    value = scope:loser.var:estate_cossacks_war_lost
+                }
+            }
+        }
+
+        scope:loser = {
+            "estate(estate_type:nobles_estate)" = {
+                estate_add_gold = {
+                    value = {
+                        value = scope:loser.var:estate_nobles_war_lost
+                        multiply = -1
+                    }
+                }
+            }
+            "estate(estate_type:burghers_estate)" = {
+                estate_add_gold = {
+                    value = {
+                        value = scope:loser.var:estate_burghers_war_lost
+                        multiply = -1
+                    }
+                }
+            }
+            "estate(estate_type:clergy_estate)" = {
+                estate_add_gold = {
+                    value = {
+                        value = scope:loser.var:estate_clergy_war_lost
+                        multiply = -1
+                    }
+                }
+            }
+            "estate(estate_type:peasants_estate)" = {
+                estate_add_gold = {
+                    value = {
+                        value = scope:loser.var:estate_peasants_war_lost
+                        multiply = -1
+                    }
+                }
+            }
+            "estate(estate_type:tribes_estate)" = {
+                estate_add_gold = {
+                    value = {
+                        value = scope:loser.var:estate_tribes_war_lost
+                        multiply = -1
+                    }
+                }
+            }
+            "estate(estate_type:dhimmi_estate)" = {
+                estate_add_gold = {
+                    value = {
+                        value = scope:loser.var:estate_dhimmi_war_lost
+                        multiply = -1
+                    }
+                }
+            }
+            "estate(estate_type:cossacks_estate)" = {
+                estate_add_gold = {
+                    value = {
+                        value = scope:loser.var:estate_cossacks_war_lost
+                        multiply = -1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/in_game/common/on_action/MnT_hardcoded.txt
+++ b/in_game/common/on_action/MnT_hardcoded.txt
@@ -429,15 +429,20 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:nobles_estate)" = {
-                        estate_add_gold = {
-                            value = "scope:target.estate(estate_type:nobles_estate).estate_gold"
-                        }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:nobles:Before:[THIS.GetEstate.GetGold]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:nobles_estate).estate_gold" }
+                        estate_add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:nobles:After:[THIS.GetEstate.GetGold]"
                     }
+
                 } else = {
                     root = {
-                        add_gold = {
-                            value = "scope:target.estate(estate_type:nobles_estate).estate_gold"
-                        }
+						error_log = "WT::crown<-nobles:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:nobles_estate).estate_gold" }
+                        add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::crown<-nobles:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
                     }
                 }
             }
@@ -452,15 +457,19 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:burghers_estate)" = {
-                        estate_add_gold = {
-                            value = "scope:target.estate(estate_type:burghers_estate).estate_gold"
-                        }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:burghers:Before:[THIS.GetEstate.GetGold]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:burghers_estate).estate_gold" }
+                        estate_add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:burghers:After:[THIS.GetEstate.GetGold]"
                     }
                 } else = {
                     root = {
-                        add_gold = {
-                            value = "scope:target.estate(estate_type:burghers_estate).estate_gold"
-                        }
+                        error_log = "WT::crown<-burghers:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:burghers_estate).estate_gold" }
+                        add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::crown<-burghers:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
                     }
                 }
             }
@@ -475,15 +484,19 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:clergy_estate)" = {
-                        estate_add_gold = {
-                            value = "scope:target.estate(estate_type:clergy_estate).estate_gold"
-                        }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:clergy:Before:[THIS.GetEstate.GetGold]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:clergy_estate).estate_gold" }
+                        estate_add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:clergy:After:[THIS.GetEstate.GetGold]"
                     }
                 } else = {
                     root = {
-                        add_gold = {
-                            value = "scope:target.estate(estate_type:clergy_estate).estate_gold"
-                        }
+                        error_log = "WT::crown<-clergy:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:clergy_estate).estate_gold" }
+                        add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::crown<-clergy:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
                     }
                 }
             }
@@ -498,15 +511,19 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:peasants_estate)" = {
-                        estate_add_gold = {
-                            value = "scope:target.estate(estate_type:peasants_estate).estate_gold"
-                        }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:peasants:Before:[THIS.GetEstate.GetGold]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:peasants_estate).estate_gold" }
+                        estate_add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:peasants:After:[THIS.GetEstate.GetGold]"
                     }
                 } else = {
                     root = {
-                        add_gold = {
-                            value = "scope:target.estate(estate_type:peasants_estate).estate_gold"
-                        }
+                        error_log = "WT::crown<-peasants:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:peasants_estate).estate_gold" }
+                        add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::crown<-peasants:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
                     }
                 }
             }
@@ -521,15 +538,19 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:tribes_estate)" = {
-                        estate_add_gold = {
-                            value = "scope:target.estate(estate_type:tribes_estate).estate_gold"
-                        }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:tribes:Before:[THIS.GetEstate.GetGold]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:tribes_estate).estate_gold" }
+                        estate_add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:tribes:After:[THIS.GetEstate.GetGold]"
                     }
                 } else = {
                     root = {
-                        add_gold = {
-                            value = "scope:target.estate(estate_type:tribes_estate).estate_gold"
-                        }
+                        error_log = "WT::crown<-tribes:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:tribes_estate).estate_gold" }
+                        add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::crown<-tribes:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
                     }
                 }
             }
@@ -544,41 +565,49 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:dhimmi_estate)" = {
-                        estate_add_gold = {
-                            value = "scope:target.estate(estate_type:dhimmi_estate).estate_gold"
-                        }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:dhimmi:Before:[THIS.GetEstate.GetGold]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:dhimmi_estate).estate_gold" }
+                        estate_add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:dhimmi:After:[THIS.GetEstate.GetGold]"
                     }
                 } else = {
                     root = {
-                        add_gold = {
-                            value = "scope:target.estate(estate_type:dhimmi_estate).estate_gold"
-                        }
+                        error_log = "WT::crown<-dhimmi:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:dhimmi_estate).estate_gold" }
+                        add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::crown<-dhimmi:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
                     }
                 }
             }
             if = {
-                limit = {
-                    country_has_estate = estate_type:cossacks_estate
-                }
-                if = {
-                    limit = {
-                        root = {
-                            country_has_estate = estate_type:cossacks_estate
-                        }
-                    }
-                    "root.estate(estate_type:cossacks_estate)" = {
-                        estate_add_gold = {
-                            value = "scope:target.estate(estate_type:cossacks_estate).estate_gold"
-                        }
-                    }
-                } else = {
-                    root = {
-                        add_gold = {
-                            value = "scope:target.estate(estate_type:cossacks_estate).estate_gold"
-                        }
-                    }
-                }
-            }
+				limit = {
+					country_has_estate = estate_type:cossacks_estate
+				}
+				if = {
+					limit = {
+						root = {
+							country_has_estate = estate_type:cossacks_estate
+						}
+					}
+					"root.estate(estate_type:cossacks_estate)" = {
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:cossacks:Before:[THIS.GetEstate.GetGold]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:cossacks_estate).estate_gold" }
+						estate_add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:cossacks:After:[THIS.GetEstate.GetGold]"
+					}
+				} else = {
+					root = {
+						error_log = "WT::crown<-cossacks:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:cossacks_estate).estate_gold" }
+						add_gold = { value = local_var:ducats_to_add }
+						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
+						error_log = "WT::crown<-cossacks:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
+					}
+				}
+			}
         }
     }
 }

--- a/in_game/common/on_action/MnT_hardcoded.txt
+++ b/in_game/common/on_action/MnT_hardcoded.txt
@@ -429,20 +429,18 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:nobles_estate)" = {
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:nobles:Before:[THIS.GetEstate.GetGold]"
+						print_annex_estate_before = { text = "nobles:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:nobles_estate).estate_gold" }
                         estate_add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:nobles:After:[THIS.GetEstate.GetGold]"
+						print_annex_estate_after = { text = "nobles" }
                     }
 
                 } else = {
                     root = {
-						error_log = "WT::crown<-nobles:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_before = { text = "crown<-nobles:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:nobles_estate).estate_gold" }
                         add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::crown<-nobles:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_after = { text = "crown<-nobles" }
                     }
                 }
             }
@@ -457,19 +455,17 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:burghers_estate)" = {
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:burghers:Before:[THIS.GetEstate.GetGold]"
+						print_annex_estate_before = { text = "burghers:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:burghers_estate).estate_gold" }
                         estate_add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:burghers:After:[THIS.GetEstate.GetGold]"
+						print_annex_estate_after = { text = "burghers" }
                     }
                 } else = {
                     root = {
-                        error_log = "WT::crown<-burghers:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_before = { text = "crown<-burghers:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:burghers_estate).estate_gold" }
                         add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::crown<-burghers:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_after = { text = "crown<-burghers" }
                     }
                 }
             }
@@ -484,19 +480,17 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:clergy_estate)" = {
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:clergy:Before:[THIS.GetEstate.GetGold]"
+						print_annex_estate_before = { text = "clergy:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:clergy_estate).estate_gold" }
                         estate_add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:clergy:After:[THIS.GetEstate.GetGold]"
+						print_annex_estate_after = { text = "clergy" }
                     }
                 } else = {
                     root = {
-                        error_log = "WT::crown<-clergy:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_before = { text = "crown<-clergy:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:clergy_estate).estate_gold" }
                         add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::crown<-clergy:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_after = { text = "crown<-clergy" }
                     }
                 }
             }
@@ -511,19 +505,17 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:peasants_estate)" = {
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:peasants:Before:[THIS.GetEstate.GetGold]"
+						print_annex_estate_before = { text = "peasants:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:peasants_estate).estate_gold" }
                         estate_add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:peasants:After:[THIS.GetEstate.GetGold]"
+						print_annex_estate_after = { text = "peasants" }
                     }
                 } else = {
                     root = {
-                        error_log = "WT::crown<-peasants:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_before = { text = "crown<-peasants:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:peasants_estate).estate_gold" }
                         add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::crown<-peasants:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_after = { text = "crown<-peasants" }
                     }
                 }
             }
@@ -538,19 +530,17 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:tribes_estate)" = {
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:tribes:Before:[THIS.GetEstate.GetGold]"
+						print_annex_estate_before = { text = "tribes:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:tribes_estate).estate_gold" }
                         estate_add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:tribes:After:[THIS.GetEstate.GetGold]"
+						print_annex_estate_after = { text = "tribes" }
                     }
                 } else = {
                     root = {
-                        error_log = "WT::crown<-tribes:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+                        print_annex_crown_before = { text = "crown<-tribes:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:tribes_estate).estate_gold" }
                         add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::crown<-tribes:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_after = { text = "crown<-tribes" }
                     }
                 }
             }
@@ -565,19 +555,17 @@ MnT_on_annex = {
                         }
                     }
                     "root.estate(estate_type:dhimmi_estate)" = {
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:dhimmi:Before:[THIS.GetEstate.GetGold]"
+						print_annex_estate_before = { text = "dhimmi:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:dhimmi_estate).estate_gold" }
                         estate_add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:dhimmi:After:[THIS.GetEstate.GetGold]"
+						print_annex_estate_after = { text = "dhimmi" }
                     }
                 } else = {
                     root = {
-                        error_log = "WT::crown<-dhimmi:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_before = { text = "crown<-dhimmi:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:dhimmi_estate).estate_gold" }
                         add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::crown<-dhimmi:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_after = { text = "crown<-dhimmi" }
                     }
                 }
             }
@@ -592,19 +580,17 @@ MnT_on_annex = {
 						}
 					}
 					"root.estate(estate_type:cossacks_estate)" = {
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:cossacks:Before:[THIS.GetEstate.GetGold]"
+						print_annex_estate_before = { text = "cossacks:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:cossacks_estate).estate_gold" }
 						estate_add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]:cossacks:After:[THIS.GetEstate.GetGold]"
+						print_annex_estate_after = { text = "cossacks" }
 					}
 				} else = {
 					root = {
-						error_log = "WT::crown<-cossacks:Before:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_before = { text = "crown<-cossacks:Before" }
 						set_local_variable = { name = ducats_to_add value = "scope:target.estate(estate_type:cossacks_estate).estate_gold" }
 						add_gold = { value = local_var:ducats_to_add }
-						error_log = "WT::Wealth received:[SCOPE.GetLocalVariable('ducats_to_add').GetValue]"
-						error_log = "WT::crown<-cossacks:After:[THIS.GetCountry.GetCurrencyValue('gold')]"
+						print_annex_crown_after = { text = "crown<-cossacks" }
 					}
 				}
 			}

--- a/in_game/common/on_action/MnT_hardcoded.txt
+++ b/in_game/common/on_action/MnT_hardcoded.txt
@@ -8,25 +8,35 @@
 # on_pre_losing_war => on_took_location_in_peace_treaty => on_losing_war
 # Both on_pre_losing_war and on_losing_war seems to be triggered twice though
 
+#root = country, scope:winner = country, scope:loser = country, scope:war = war
 on_pre_losing_war = {
     on_actions = {
         MnT_on_pre_losing_war
     }
 }
 
+#root = winner, scope:location = location, scope:winner = new owner, scope:loser = old owner
 on_took_location_in_peace_treaty = {
     on_actions = {
         MnT_took_location_in_peace_treaty
     }
 }
 
+#root = country, scope:winner = country, scope:loser = country, scope:war = war
 on_losing_war = {
     on_actions = {
         MnT_on_losing_war
     }
 }
 
+# fired before the annexation happens; root =  country doing the annexing ,  scope:target = country being annexed
+on_annex = {
+    on_actions = {
+        MnT_on_annex
+    }
+}
 
+#root = country, scope:winner = country, scope:loser = country, scope:war = war
 MnT_on_pre_losing_war = {
     effect = {
         scope:loser = {
@@ -91,6 +101,8 @@ MnT_on_pre_losing_war = {
     }
 }
 
+#root = winner, scope:location = location, scope:winner = new owner, scope:loser = old owner
+#Note that the location's ownership is already transferred when this triggers
 MnT_took_location_in_peace_treaty = {
     effect = {
         scope:location = {
@@ -218,6 +230,7 @@ MnT_took_location_in_peace_treaty = {
     }
 }
 
+#root = country, scope:winner = country, scope:loser = country, scope:war = war
 MnT_on_losing_war = {
     trigger = {
         scope:loser = {
@@ -383,6 +396,186 @@ MnT_on_losing_war = {
                     value = {
                         value = scope:loser.var:estate_cossacks_war_lost
                         multiply = -1
+                    }
+                }
+            }
+        }
+    }
+}
+
+# fired before the annexation happens; root =  country doing the annexing ,  scope:target = country being annexed
+MnT_on_annex = {
+    trigger = {
+        scope:target = {
+            NOT = {
+                has_variable = on_annex_triggered
+            }
+        }
+    }
+    effect = {
+        scope:target = {
+            set_variable = {
+                name = on_annex_triggered
+                value = 1
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:nobles_estate
+                }
+                if = {
+                    limit = {
+                        root = {
+                            country_has_estate = estate_type:nobles_estate
+                        }
+                    }
+                    "root.estate(estate_type:nobles_estate)" = {
+                        estate_add_gold = {
+                            value = "scope:target.estate(estate_type:nobles_estate).estate_gold"
+                        }
+                    }
+                } else = {
+                    root = {
+                        add_gold = {
+                            value = "scope:target.estate(estate_type:nobles_estate).estate_gold"
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:burghers_estate
+                }
+                if = {
+                    limit = {
+                        root = {
+                            country_has_estate = estate_type:burghers_estate
+                        }
+                    }
+                    "root.estate(estate_type:burghers_estate)" = {
+                        estate_add_gold = {
+                            value = "scope:target.estate(estate_type:burghers_estate).estate_gold"
+                        }
+                    }
+                } else = {
+                    root = {
+                        add_gold = {
+                            value = "scope:target.estate(estate_type:burghers_estate).estate_gold"
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:clergy_estate
+                }
+                if = {
+                    limit = {
+                        root = {
+                            country_has_estate = estate_type:clergy_estate
+                        }
+                    }
+                    "root.estate(estate_type:clergy_estate)" = {
+                        estate_add_gold = {
+                            value = "scope:target.estate(estate_type:clergy_estate).estate_gold"
+                        }
+                    }
+                } else = {
+                    root = {
+                        add_gold = {
+                            value = "scope:target.estate(estate_type:clergy_estate).estate_gold"
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:peasants_estate
+                }
+                if = {
+                    limit = {
+                        root = {
+                            country_has_estate = estate_type:peasants_estate
+                        }
+                    }
+                    "root.estate(estate_type:peasants_estate)" = {
+                        estate_add_gold = {
+                            value = "scope:target.estate(estate_type:peasants_estate).estate_gold"
+                        }
+                    }
+                } else = {
+                    root = {
+                        add_gold = {
+                            value = "scope:target.estate(estate_type:peasants_estate).estate_gold"
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:tribes_estate
+                }
+                if = {
+                    limit = {
+                        root = {
+                            country_has_estate = estate_type:tribes_estate
+                        }
+                    }
+                    "root.estate(estate_type:tribes_estate)" = {
+                        estate_add_gold = {
+                            value = "scope:target.estate(estate_type:tribes_estate).estate_gold"
+                        }
+                    }
+                } else = {
+                    root = {
+                        add_gold = {
+                            value = "scope:target.estate(estate_type:tribes_estate).estate_gold"
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:dhimmi_estate
+                }
+                if = {
+                    limit = {
+                        root = {
+                            country_has_estate = estate_type:dhimmi_estate
+                        }
+                    }
+                    "root.estate(estate_type:dhimmi_estate)" = {
+                        estate_add_gold = {
+                            value = "scope:target.estate(estate_type:dhimmi_estate).estate_gold"
+                        }
+                    }
+                } else = {
+                    root = {
+                        add_gold = {
+                            value = "scope:target.estate(estate_type:dhimmi_estate).estate_gold"
+                        }
+                    }
+                }
+            }
+            if = {
+                limit = {
+                    country_has_estate = estate_type:cossacks_estate
+                }
+                if = {
+                    limit = {
+                        root = {
+                            country_has_estate = estate_type:cossacks_estate
+                        }
+                    }
+                    "root.estate(estate_type:cossacks_estate)" = {
+                        estate_add_gold = {
+                            value = "scope:target.estate(estate_type:cossacks_estate).estate_gold"
+                        }
+                    }
+                } else = {
+                    root = {
+                        add_gold = {
+                            value = "scope:target.estate(estate_type:cossacks_estate).estate_gold"
+                        }
                     }
                 }
             }

--- a/in_game/common/scripted_effects/MnT_on_annex.txt
+++ b/in_game/common/scripted_effects/MnT_on_annex.txt
@@ -1,0 +1,19 @@
+﻿print_annex_estate_before = {
+	if = { limit = { always = no }
+	}
+}
+
+print_annex_estate_after = {
+	if = { limit = { has_global_variable = is_logging_annexation_information }
+		error_log = "WT::[THIS.GetEstate.GetCountry.GetNameWithNoTooltip]: $text$ :+[Subtract_CFixedPoint(THIS.GetEstate.GetGold, SCOPE.GetLocalVariable('ducats_to_add').GetValue)] -> [THIS.GetEstate.GetGold]" }
+}
+
+print_annex_crown_before = {
+	if = { limit = { always = no }
+	}
+}
+
+print_annex_crown_after = {
+	if = { limit = { has_global_variable =  is_logging_annexation_information }
+		error_log = "WT::[THIS.GetCountry.GetNameWithNoTooltip]: $text$ : +[SCOPE.GetLocalVariable('ducats_to_add').GetValue] -> [THIS.GetCountry.GetCurrencyValue('gold')]" }
+}

--- a/in_game/events/SYS-CENSUS.txt
+++ b/in_game/events/SYS-CENSUS.txt
@@ -33,3 +33,27 @@ LOGGER_CHARTS.04 = {
 		error_log = "Logging is disabled"
 	}
 }
+
+# Enable logging annexation information
+LOGGER_CHARTS.07 = {
+	type = country_event
+	title = LOGGER_CHARTS.01.title
+	hidden = yes
+	orphan = yes
+	immediate = {
+		set_global_variable = is_logging_annexation_information
+		error_log = "Enabled: Logging annexation information"
+	}
+}
+
+# Disable logging annexation information
+LOGGER_CHARTS.08 = {
+	type = country_event
+	title = LOGGER_CHARTS.01.title
+	hidden = yes
+	orphan = yes
+	immediate = {
+		remove_global_variable = is_logging_annexation_information
+		error_log = "Disabled: Logging annexation information"
+	}
+}


### PR DESCRIPTION
Resolves #77.
On annexation, the wealth of each estate of the annexed country will be transferred to the corresponding estate of the annexing country. If that estate does not exist for some reason, the wealth goes to the treasury. I don't want to come up with some fancy logic to deal with edge cases; hopefully this will be good enough.
When taking locations in a peace treaty, a proportion of the total wealth of the losing country will be transferred in a similar way to the winning country. The proportion depends on the share of the ceded locations' potential tax base compared to the total potential tax base of the losing country before the war ends. It's a crude heuristic but I think we don't need to spend much time on this: ultimately this issue will be addressed when we have location level wealth tracking.
