### PR TITLE
chore(workflow): allow merge commits to bypass changelog requirement

### DIFF
--- a/.github/workflows/require-changelog.yml
+++ b/.github/workflows/require-changelog.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Check if all commits are in ignored types
         id: check_ignored
         run: |
-          allowed_re='^(build|chore|ci|docs|style|refactor|perf|test)(\(.+\))?:'
+          allowed_re='^((build|chore|ci|docs|style|refactor|perf|test)(\([^)]+\))?:|Merge )'
           all_allowed=true
 
           while IFS= read -r msg; do
             [ -z "$msg" ] && continue
-            if ! echo "$msg" | grep -Eq "$allowed_re"; then
+            if ! echo "$msg" | grep -Eqi "$allowed_re"; then
               all_allowed=false
               break
             fi


### PR DESCRIPTION
Pretty self-explanatory, allow Merge commits to non-changelog requiring branches to not make changelog required