### PR TITLE
Make upstream cost the same as downstream

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -74,8 +74,8 @@ Date: 2025-11-30
     - Proximity Cost through Roads: 20 → 15  
     - Proximity Cost through Land: 40 → 30  
     - Proximity Cost through Port: 40 → 30  
-    - Proximity Cost of going upstream along a River: 30 → 7  
-    - Proximity Cost of going downstream along a River: 10 → 7  
+    - Proximity Cost of going upstream along a River: 30 → 11
+    - Proximity Cost of going downstream along a River: 10 → 11  
     - Proximity Cost on Frozen Water: 20 → 15  
   - Roads  
     - Build cost scaled & maintenance market demands scaled  
@@ -90,7 +90,7 @@ Date: 2025-11-30
     - Paved road: \-15% → \-30%  
     - Modern road: \-20% → \-40%  
     - Railroad: \-25% → \-50%  
-  - Market access cost of rivers equalized up and downstream from 0.9 → 0.5
+  - Market access cost of rivers equalized up and downstream from 0.9 → 0.7
   - Sliders generate market demand:  
     - Cost of the Court: furniture, tools, glass, fine cloth  
     - Diplomatic expenses: paper, jewelry  

--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -74,7 +74,7 @@ Date: 2025-11-30
     - Proximity Cost through Roads: 20 → 15  
     - Proximity Cost through Land: 40 → 30  
     - Proximity Cost through Port: 40 → 30  
-    - Proximity Cost of going upstream along a River: 30 → 22  
+    - Proximity Cost of going upstream along a River: 30 → 7  
     - Proximity Cost of going downstream along a River: 10 → 7  
     - Proximity Cost on Frozen Water: 20 → 15  
   - Roads  
@@ -90,6 +90,7 @@ Date: 2025-11-30
     - Paved road: \-15% → \-30%  
     - Modern road: \-20% → \-40%  
     - Railroad: \-25% → \-50%  
+  - Market access cost of rivers equalized up and downstream from 0.9 → 0.5
   - Sliders generate market demand:  
     - Cost of the Court: furniture, tools, glass, fine cloth  
     - Diplomatic expenses: paper, jewelry  

--- a/in_game/common/auto_modifiers/MnT_country.txt
+++ b/in_game/common/auto_modifiers/MnT_country.txt
@@ -116,8 +116,8 @@ REPLACE:country_base_values = {
 	road_cost_on_distance_from_capital = 15 #M&T from 20
 	land_cost_on_distance_from_capital = 30 #M&T from 40
 	port_cost_distance_from_capital = 30 #M&T from 40
-	land_cost_going_upstream	= 4 #M&T from 10
-	land_cost_going_downstream	= 4 #M&T from 10
+	land_cost_going_upstream	= 11 #M&T from 10
+	land_cost_going_downstream	= 11 #M&T from 10
 	land_cost_on_frozen_water = 15 #M&T from 20
 	
 	global_migration_speed = 0.0001

--- a/in_game/common/auto_modifiers/MnT_country.txt
+++ b/in_game/common/auto_modifiers/MnT_country.txt
@@ -116,8 +116,8 @@ REPLACE:country_base_values = {
 	road_cost_on_distance_from_capital = 15 #M&T from 20
 	land_cost_on_distance_from_capital = 30 #M&T from 40
 	port_cost_distance_from_capital = 30 #M&T from 40
-	land_cost_going_upstream	= 7 #M&T from 10
-	land_cost_going_downstream	= 7 #M&T from 10
+	land_cost_going_upstream	= 4 #M&T from 10
+	land_cost_going_downstream	= 4 #M&T from 10
 	land_cost_on_frozen_water = 15 #M&T from 20
 	
 	global_migration_speed = 0.0001

--- a/in_game/common/auto_modifiers/MnT_country.txt
+++ b/in_game/common/auto_modifiers/MnT_country.txt
@@ -116,7 +116,7 @@ REPLACE:country_base_values = {
 	road_cost_on_distance_from_capital = 15 #M&T from 20
 	land_cost_on_distance_from_capital = 30 #M&T from 40
 	port_cost_distance_from_capital = 30 #M&T from 40
-	land_cost_going_upstream	= 22 #M&T from 30
+	land_cost_going_upstream	= 7 #M&T from 10
 	land_cost_going_downstream	= 7 #M&T from 10
 	land_cost_on_frozen_water = 15 #M&T from 20
 	

--- a/loading_screen/common/defines/MnT_NMarket.txt
+++ b/loading_screen/common/defines/MnT_NMarket.txt
@@ -1,4 +1,4 @@
 ﻿NMarket = {
-	MARKET_DOWNSTREAM_FACTOR = 0.5 # downstream is great! #M&T from 0.9
-	MARKET_UPSTREAM_FACTOR = 0.5   #better upstream than not..
+	MARKET_DOWNSTREAM_FACTOR = 0.7 # downstream is great! #M&T from 0.9
+	MARKET_UPSTREAM_FACTOR = 0.7   #better upstream than not..
 }

--- a/loading_screen/common/defines/MnT_NMarket.txt
+++ b/loading_screen/common/defines/MnT_NMarket.txt
@@ -1,0 +1,4 @@
+﻿NMarket = {
+	MARKET_DOWNSTREAM_FACTOR = 0.5 # downstream is great! #M&T from 0.9
+	MARKET_UPSTREAM_FACTOR = 0.5   #better upstream than not..
+}


### PR DESCRIPTION
both market and proximity equalized. Market river discount at 0.5, could reduce to 0.7 to reduce market bordergore.