### PR TITLE
fix(gui): unify goods RGO buttons with production toggle state

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -265,6 +265,7 @@ Date: 2026-01-20
 - Added Goods Domestic Product UI in the Economy panel
 - Added fIlter button for rgo buildings in building view
 - Changed the behaviour of brgo buttons to show rgo buildings 
+- Unified goods-panel RGO buttons with the Production view RGO visibility toggle and removed sticky per-good RGO force-show state.
 
 ##### Modding
 - Added automated check for correct encodings via GitHub Actions

--- a/in_game/common/scripted_guis/MnT_clear_rgo_filters.txt
+++ b/in_game/common/scripted_guis/MnT_clear_rgo_filters.txt
@@ -4,6 +4,8 @@
 	is_valid = { is_ai = no }
 
 	effect = {
+		# Clear transient category/building forcing only.
+		# Keep mnt_show_rgo_buildings untouched (single shared toggle state).
 		remove_variable = mnt_force_show_rgo_category
 		remove_variable = mnt_force_show_non_rgo_category
 		remove_variable = mnt_country_force_show_buildings

--- a/in_game/common/scripted_guis/MnT_toggle_rgo_buildings_visibility.txt
+++ b/in_game/common/scripted_guis/MnT_toggle_rgo_buildings_visibility.txt
@@ -1,4 +1,35 @@
-﻿mnt_toggle_rgo_buildings_visibility = {
+# Single source of truth for RGO visibility in Production view.
+# Goods view actions should call the explicit ON/OFF scripted GUIs below.
+
+mnt_set_rgo_buildings_visible_on = {
+	scope = country
+	is_shown = { is_ai = no }
+	is_valid = { is_ai = no }
+
+	effect = {
+		# Clear transient force-show filters so this state fully controls visibility.
+		remove_variable = mnt_force_show_rgo_category
+		remove_variable = mnt_force_show_non_rgo_category
+		remove_variable = mnt_country_force_show_buildings
+		set_variable = { name = mnt_show_rgo_buildings value = 1 }
+	}
+}
+
+mnt_set_rgo_buildings_visible_off = {
+	scope = country
+	is_shown = { is_ai = no }
+	is_valid = { is_ai = no }
+
+	effect = {
+		# Clear transient force-show filters so this state fully controls visibility.
+		remove_variable = mnt_force_show_rgo_category
+		remove_variable = mnt_force_show_non_rgo_category
+		remove_variable = mnt_country_force_show_buildings
+		remove_variable = mnt_show_rgo_buildings
+	}
+}
+
+mnt_toggle_rgo_buildings_visibility = {
 	scope = country
 	is_shown = { is_ai = no }
 	is_valid = { is_ai = no }

--- a/in_game/gui/goods_production_lateralview.gui
+++ b/in_game/gui/goods_production_lateralview.gui
@@ -191,9 +191,10 @@ lateralview = {
 									action_tooltip = {
 										click_type = left
 										click_mode = single
-											title = "OPEN_RGO_BUILDER"
-											on_action = "[GetScriptedGui('mnt_force_show_rgo_category_on').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
-											on_action = "[OpenLateralViewWithFilter('production', 'rgo_building_category')]"
+										title = "OPEN_RGO_BUILDER"
+										# Keep Goods and Production toggle state in sync.
+										on_action = "[GetScriptedGui('mnt_set_rgo_buildings_visible_on').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
+										on_action = "[OpenLateralViewWithFilter('production', 'rgo_building_category')]"
 									}
 									
 									text = "OPEN_RGO_BUILDER"
@@ -792,16 +793,17 @@ lateralview = {
 															}
 														}
 													}
-													action_tooltip = {
-														click_type = left
-														click_mode = single
-														enabled = "[GoodItem.CanBuildBuildings]"
-														conditions = "[MakeItFailIfLoc(Not(GoodItem.CanBuildBuildings), 'GOODS_EXPAND_BUILDING_REQUIREMENTS_NOT_MET')]"
-												title = "GOODS_EXPAND_BUILDING_TT"
-												on_action = "[GetScriptedGui('mnt_force_show_non_rgo_category_on').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
-												on_action = "[OpenLateralViewWithFilter('production', GoodItem.GetGoods.GetKey)]"
-												on_action = "[OpenLateralViewWithParams('production', 'display = lists')]"
-													}
+									action_tooltip = {
+										click_type = left
+										click_mode = single
+										enabled = "[GoodItem.CanBuildBuildings]"
+										conditions = "[MakeItFailIfLoc(Not(GoodItem.CanBuildBuildings), 'GOODS_EXPAND_BUILDING_REQUIREMENTS_NOT_MET')]"
+										title = "GOODS_EXPAND_BUILDING_TT"
+										# Left button mirrors Production's "hide RGO" state.
+										on_action = "[GetScriptedGui('mnt_set_rgo_buildings_visible_off').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
+										on_action = "[OpenLateralViewWithFilter('production', GoodItem.GetGoods.GetKey)]"
+										on_action = "[OpenLateralViewWithParams('production', 'display = lists')]"
+									}
 													hbox = {
 														margin = {10 0}
 														icon = {
@@ -880,16 +882,16 @@ lateralview = {
 															}
 														}
 													}
-													action_tooltip = {
-														click_type = left
-														click_mode = single
-														enabled = "[GoodItem.CanExpandRGO]"
-												title = "GOODS_EXPAND_RGO_TT"
-												conditions = "[MakeItFailIfLoc(Not(GoodItem.CanExpandRGO), 'GOODS_EXPAND_BUILDING_REQUIREMENTS_NOT_MET')]"
-												on_action = "[GetScriptedGui('mnt_force_show_rgo_category_on').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
-												on_action = "[GetScriptedGui('mnt_force_show_rgo_building').Execute(GuiScope.SetRoot(Player.MakeScope).AddScope('goods', GoodItem.GetGoods.MakeScope).End)]"
-												on_action = "[OpenLateralViewWithFilter('production', GoodItem.GetGoods.GetKey)]"
-													}
+									action_tooltip = {
+										click_type = left
+										click_mode = single
+										enabled = "[GoodItem.CanExpandRGO]"
+										title = "GOODS_EXPAND_RGO_TT"
+										conditions = "[MakeItFailIfLoc(Not(GoodItem.CanExpandRGO), 'GOODS_EXPAND_BUILDING_REQUIREMENTS_NOT_MET')]"
+										# Right button mirrors Production's "show RGO" state.
+										on_action = "[GetScriptedGui('mnt_set_rgo_buildings_visible_on').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
+										on_action = "[OpenLateralViewWithFilter('production', GoodItem.GetGoods.GetKey)]"
+									}
 
 													icon = {
 												visible = "[And(GoodItem.AreAllPossibleRGOAtMaxLvl, GreaterThan_CFixedPoint(GoodItem.GetMaxRGOIncome,'(CFixedPoint)0'))]"


### PR DESCRIPTION
This pull request refactors how the visibility of RGO buildings is managed in the Production and Goods views, consolidating the toggle logic and ensuring both views stay in sync. The main improvement is introducing explicit ON/OFF scripted GUIs for RGO visibility, replacing the previous force-show filters and making the toggle state consistent across the UI.

**RGO Visibility Toggle Refactor:**

* Added new scripted GUIs: `mnt_set_rgo_buildings_visible_on` and `mnt_set_rgo_buildings_visible_off`, which explicitly control the RGO buildings visibility state and clear any transient force-show filters to ensure a single source of truth. (`in_game/common/scripted_guis/MnT_toggle_rgo_buildings_visibility.txt` [in_game/common/scripted_guis/MnT_toggle_rgo_buildings_visibility.txtL1-R32](diffhunk://#diff-2e5d2c2f79f13d94f23a969b43027bc42815b59a2d407621200686e97bad9539L1-R32))
* Updated the Production and Goods lateral view actions to use the new ON/OFF scripted GUIs, ensuring both views update the RGO visibility state consistently when toggled. (`in_game/gui/goods_production_lateralview.gui` [[1]](diffhunk://#diff-8b97b4e5b09bccb4a1057129045886bf5811314107c65cb348022c46611336b1L195-R196) [[2]](diffhunk://#diff-8b97b4e5b09bccb4a1057129045886bf5811314107c65cb348022c46611336b1L801-R803) [[3]](diffhunk://#diff-8b97b4e5b09bccb4a1057129045886bf5811314107c65cb348022c46611336b1L889-R892)

**Cleanup of Transient Filters:**

* Modified the clear filters script to only remove transient category/building forcing variables, preserving the shared toggle state variable (`mnt_show_rgo_buildings`). (`in_game/common/scripted_guis/MnT_clear_rgo_filters.txt` [in_game/common/scripted_guis/MnT_clear_rgo_filters.txtR7-R8](diffhunk://#diff-ce422b80fc4d8f960efcd08ef250bf17cd3b69d4bc4822c5b6f0218af8371381R7-R8))