### PR TITLE
Feature/local gui include rgo buildings

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -266,6 +266,8 @@ Date: 2026-01-20
 - Added fIlter button for rgo buildings in building view
 - Changed the behaviour of brgo buttons to show rgo buildings 
 - Unified goods-panel RGO buttons with the Production view RGO visibility toggle and removed sticky per-good RGO force-show state.
+- Reworked the location window RGO button to open Location Production filtered to the selected location's raw material building path.
+- Updated the location window RGO value readout to show current RGO building level versus location-specific maximum level.
 
 ##### Modding
 - Added automated check for correct encodings via GitHub Actions

--- a/in_game/common/script_values/MnT_rgo_ui_values.txt
+++ b/in_game/common/script_values/MnT_rgo_ui_values.txt
@@ -1,4 +1,4 @@
-# UI helper values for the location RGO button.
+﻿# UI helper values for the location RGO button.
 # They resolve the active RGO building level and max level for the location's raw material.
 
 mnt_location_current_rgo_building_level = {

--- a/in_game/common/script_values/MnT_rgo_ui_values.txt
+++ b/in_game/common/script_values/MnT_rgo_ui_values.txt
@@ -1,0 +1,62 @@
+# UI helper values for the location RGO button.
+# They resolve the active RGO building level and max level for the location's raw material.
+
+mnt_location_current_rgo_building_level = {
+	# Built-in current RGO level for the location's active raw material.
+	value = rgo_building_level
+}
+
+mnt_location_max_rgo_building_level = {
+	if = { limit = { raw_material = goods:alum } value = rgo_alum_max_level }
+	if = { limit = { raw_material = goods:amber } value = rgo_amber_max_level }
+	if = { limit = { raw_material = goods:beeswax } value = rgo_beeswax_max_level }
+	if = { limit = { raw_material = goods:chili } value = rgo_chili_max_level }
+	if = { limit = { raw_material = goods:clay } value = rgo_clay_max_level }
+	if = { limit = { raw_material = goods:cloves } value = rgo_cloves_max_level }
+	if = { limit = { raw_material = goods:coal } value = rgo_coal_max_level }
+	if = { limit = { raw_material = goods:cocoa } value = rgo_cocoa_max_level }
+	if = { limit = { raw_material = goods:coffee } value = rgo_coffee_max_level }
+	if = { limit = { raw_material = goods:copper } value = rgo_copper_max_level }
+	if = { limit = { raw_material = goods:cotton } value = rgo_cotton_max_level }
+	if = { limit = { raw_material = goods:dyes } value = rgo_dyes_max_level }
+	if = { limit = { raw_material = goods:elephants } value = rgo_elephants_max_level }
+	if = { limit = { raw_material = goods:fiber_crops } value = rgo_fiber_crops_max_level }
+	if = { limit = { raw_material = goods:fish } value = rgo_fish_max_level }
+	if = { limit = { raw_material = goods:fruit } value = rgo_fruit_max_level }
+	if = { limit = { raw_material = goods:fur } value = rgo_fur_max_level }
+	if = { limit = { raw_material = goods:gems } value = rgo_gems_max_level }
+	if = { limit = { raw_material = goods:goods_gold } value = rgo_goods_gold_max_level }
+	if = { limit = { raw_material = goods:horses } value = rgo_horses_max_level }
+	if = { limit = { raw_material = goods:incense } value = rgo_incense_max_level }
+	if = { limit = { raw_material = goods:iron } value = rgo_iron_max_level }
+	if = { limit = { raw_material = goods:ivory } value = rgo_ivory_max_level }
+	if = { limit = { raw_material = goods:lead } value = rgo_lead_max_level }
+	if = { limit = { raw_material = goods:legumes } value = rgo_legumes_max_level }
+	if = { limit = { raw_material = goods:livestock } value = rgo_livestock_max_level }
+	if = { limit = { raw_material = goods:lumber } value = rgo_lumber_max_level }
+	if = { limit = { raw_material = goods:maize } value = rgo_maize_max_level }
+	if = { limit = { raw_material = goods:marble } value = rgo_marble_max_level }
+	if = { limit = { raw_material = goods:medicaments } value = rgo_medicaments_max_level }
+	if = { limit = { raw_material = goods:mercury } value = rgo_mercury_max_level }
+	if = { limit = { raw_material = goods:millet } value = rgo_millet_max_level }
+	if = { limit = { raw_material = goods:olives } value = rgo_olives_max_level }
+	if = { limit = { raw_material = goods:pearls } value = rgo_pearls_max_level }
+	if = { limit = { raw_material = goods:pepper } value = rgo_pepper_max_level }
+	if = { limit = { raw_material = goods:potato } value = rgo_potato_max_level }
+	if = { limit = { raw_material = goods:rice } value = rgo_rice_max_level }
+	if = { limit = { raw_material = goods:saffron } value = rgo_saffron_max_level }
+	if = { limit = { raw_material = goods:salt } value = rgo_salt_max_level }
+	if = { limit = { raw_material = goods:saltpeter } value = rgo_saltpeter_max_level }
+	if = { limit = { raw_material = goods:sand } value = rgo_sand_max_level }
+	if = { limit = { raw_material = goods:silk } value = rgo_silk_max_level }
+	if = { limit = { raw_material = goods:silver } value = rgo_silver_max_level }
+	if = { limit = { raw_material = goods:stone } value = rgo_stone_max_level }
+	if = { limit = { raw_material = goods:sugar } value = rgo_sugar_max_level }
+	if = { limit = { raw_material = goods:tea } value = rgo_tea_max_level }
+	if = { limit = { raw_material = goods:tin } value = rgo_tin_max_level }
+	if = { limit = { raw_material = goods:tobacco } value = rgo_tobacco_max_level }
+	if = { limit = { raw_material = goods:wheat } value = rgo_wheat_max_level }
+	if = { limit = { raw_material = goods:wild_game } value = rgo_wild_game_max_level }
+	if = { limit = { raw_material = goods:wine } value = rgo_wine_max_level }
+	if = { limit = { raw_material = goods:wool } value = rgo_wool_max_level }
+}

--- a/in_game/common/scripted_effects/MnT_calc_location_produced_goods_value.txt
+++ b/in_game/common/scripted_effects/MnT_calc_location_produced_goods_value.txt
@@ -388,14 +388,6 @@ calc_location_total_profit_value_added = {
             multiply = "scope:target_location.raw_material.price_in_market(scope:target_location.market)"
         }
     }
-    # calc total 
-    set_variable = {
-        name = mnt_loc_total_value_added
-        value = {
-            value = var:mnt_loc_building_profit
-            add = var:mnt_loc_rgo_value
-        }
-    }
 }
 
 # Calculates the combined urban + rural goods value across all owned locations for a country.

--- a/in_game/common/scripted_effects/MnT_hide_RGOs.txt
+++ b/in_game/common/scripted_effects/MnT_hide_RGOs.txt
@@ -1,29 +1,9 @@
-﻿# Add a building type to the list of types to hide in a country scope
-# ROOT: country
-# ARGS: building_type
-mnt_country_hide_building = {
-	add_to_variable_list = {
-		name = mnt_country_hidden_buildings
-		target = $building_type$
-	}
-}
-
 # Add a building type to the list of types to hide in the global scope
 # ROOT: none
 # ARGS: building_type
 mnt_global_hide_building = {
 	add_to_global_variable_list = {
 		name = mnt_global_hidden_buildings
-		target = $building_type$
-	}
-}
-
-# Remove a building type from the list of types to hide in a country scope
-# ROOT: country
-# ARGS: building_type
-mnt_country_show_building = {
-	remove_list_variable = {
-		name = mnt_country_hidden_buildings
 		target = $building_type$
 	}
 }

--- a/in_game/common/scripted_guis/MnT_is_building_shown.txt
+++ b/in_game/common/scripted_guis/MnT_is_building_shown.txt
@@ -44,12 +44,6 @@
 								name = mnt_global_hidden_buildings
 								target = this
 							}
-							scope:player = {
-								is_target_in_variable_list = {
-									name = mnt_country_hidden_buildings
-									target = prev
-								}
-							}
 						}
 					}
 				}
@@ -63,17 +57,9 @@ mnt_is_building_hidden = {
 		player
 	}
 	is_shown = {
-		OR = {
-			is_target_in_global_variable_list = {
-				name = mnt_global_hidden_buildings
-				target = this
-			}
-			scope:player = {
-				is_target_in_variable_list = {
-					name = mnt_country_hidden_buildings
-					target = prev
-				}
-			}
+		is_target_in_global_variable_list = {
+			name = mnt_global_hidden_buildings
+			target = this
 		}
 	}
 }

--- a/in_game/common/scripted_guis/MnT_toggle_rgo_buildings_visibility.txt
+++ b/in_game/common/scripted_guis/MnT_toggle_rgo_buildings_visibility.txt
@@ -1,4 +1,4 @@
-# Single source of truth for RGO visibility in Production view.
+﻿# Single source of truth for RGO visibility in Production view.
 # Goods view actions should call the explicit ON/OFF scripted GUIs below.
 
 mnt_set_rgo_buildings_visible_on = {

--- a/in_game/gui/location_window.gui
+++ b/in_game/gui/location_window.gui
@@ -1,0 +1,8796 @@
+types LocationWindowTypes
+{
+	type demography_chart = widget {
+
+		using = bg_paper_card
+		using = bg_cabinet_card_frame
+
+		hbox = {
+			using = layoutpolicy_expanding
+			margin = { 10 10 }
+			spacing = 2
+
+			hbox = {
+				layoutpolicy_vertical = expanding
+				vbox = {
+					block "piechart_block" {}
+				}
+			}
+
+			vbox = {
+				layoutpolicy_horizontal = expanding
+				layoutpolicy_vertical = expanding
+
+				vbox = {
+					margin = { 15 0 }
+					layoutpolicy_horizontal = expanding
+					using = bg_paper_card
+
+					hbox = {
+						layoutpolicy_horizontal = expanding
+						# block "subheaders" {}
+					}
+				}
+
+				scrollarea = {
+					using = layoutpolicy_expanding
+					scrollbarpolicy_horizontal = always_off
+					autoresizescrollarea = no
+
+					scrollbar_vertical = {
+						using = Scrollbar_Vertical
+					}
+
+					scrollwidget = {
+						fixedgridbox = {
+							addcolumn = 100%
+							addrow = 32
+
+							block "demography_datamodel" {}
+							item = {
+								widget = {
+									size = { 97% 32 }
+									hbox = {
+										margin = { 5 2 }
+										widget = {
+											using = layoutpolicy_expanding
+											using = bg_dark_paper_card
+
+											block "demography_item" {}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	type flags_with_limit = hbox {
+		hbox = {
+			spacing = 2
+			block "flags_with_limit_datamodel" {
+				datamodel = "[DataModelFirst(Location.GetCores,'(int32)2')]"
+			}
+			item = {
+				hbox = {
+					country_flag_small = {}
+				}
+			}
+		}
+		text_single = {
+			margin = {5 5}
+			using = Font_Type_Headers
+			block "flags_with_limit_text" {
+				raw_text = "+[Subtract_int32(GetDataModelSize(Location.GetCores), '(int32)2')]"
+			}
+			block "flags_with_limit_visible_extra" {
+				visible = "[GreaterThan_int32(GetDataModelSize(Location.GetCores), '(int32)2')]"
+			}
+			align = nobaseline
+			using = bg_number_container_bckg
+			block "flags_with_limit_tooltip_extra" {
+				tooltipwidget = {
+					using = location_core_tooltip
+				}
+			}
+			blockoverride "number_container_alpha" {
+				alpha = 0.5
+			}
+			blockoverride "number_container_color" {
+				modify_texture = {
+					using = color_bg_blue_texture
+					blend_mode = multiply
+				}
+			}
+		}
+	}
+
+	type card_button_alt = button {
+
+		background = {
+			# using = card_button_bg_alt
+			using = color_dark_brown_texture
+		}
+
+		using = card_button_alt_frame
+		using = button_common_template
+		# using = button_common_properties_template
+		blockoverride "button_text_properties" {
+			default_format = "#color_white"
+			using = Font_Type_Headers
+		}
+	}
+
+	type row_building_card = widget {
+		block "row_building_card_frame_size" {
+			size = { 100% 100% }
+			parentanchor = center
+			position = {0 0}
+		}
+		
+		background = {
+			using = bg_round_corners_alt_texture
+			margin = {-1 0}
+			modify_texture = {
+				color = "[LocationBuildingItem.GetBuilding.GetType.GetPopType.GetColor]"
+				# blend_mode = multiply
+				alpha = 0.8
+			}
+			modify_texture = {
+				using = overlay_cloth_texture
+				blend_mode = overlay
+				alpha = 0.1
+			}
+		}
+
+		using = bg_tile_shadow		
+		using = bg_cabinet_card_frame
+		blockoverride "cabinet_card_shadow" {
+			margin_bottom = 2
+			margin_top = 0
+			margin_right = 2
+		}
+		blockoverride "cabinet_card_frame" {
+			margin_bottom = 1
+			margin_top = 1
+			margin_right = 1
+		}
+
+		vbox = {
+			spacing = 1
+			widget = {
+				using = layoutpolicy_expanding
+				vbox = {
+					block "margin_size" {
+						margin_top = 23
+					}	
+					widget = {
+						layoutpolicy_horizontal = expanding
+						block "number_size" {
+							size = { -1 14 }
+						}
+						using = bg_text_mask_container_brown
+						hbox = {
+							text_single = {
+								maximumsize = { 30 14 }
+								fontsize = 13
+								align = center
+								visible = "[And3(LocationBuildingItem.IsBuilding, Not(LocationBuildingItem.GetBuilding.IsUnderConstruction), Not(And(LocationBuildingItem.GetBuilding.CanPlayerUpgrade, LocationBuildingItem.GetBuilding.IsPlayerUpgrading)))]"
+								text = "[LocationBuildingItem.GetLevel]"
+							}
+							text_single = {
+								maximumsize = { 30 14 }
+								fontsize = 13
+								align = center
+								visible = "[And4(LocationBuildingItem.IsBuilding, Not(LocationBuildingItem.GetBuilding.IsUnderConstruction), LocationBuildingItem.GetBuilding.CanPlayerUpgrade, LocationBuildingItem.GetBuilding.IsPlayerUpgrading)]"
+								raw_text = "[LocationBuildingItem.GetLevel] #G -[LocationBuildingItem.GetBuilding.GetLevelsUnderUpgrade|0]#!"
+							}
+							text_single = {
+								maximumsize = { 30 14 }
+								fontsize = 13
+								align = center
+								visible = "[And(LocationBuildingItem.IsBuilding, LocationBuildingItem.GetBuilding.IsUnderConstruction)]"
+								raw_text = "[LocationBuildingItem.GetLevel] [LocationBuildingItem.GetBuilding.GetLevelsUnderConstruction|0+=]"
+							}
+						}
+					}
+				}
+
+				card_header_button_04 = {
+					visible = "[And3(Not(LocationBuildingItem.GetBuilding.GetType.IsProducing), LocationBuildingItem.IsPlayerBuilding, Not(LocationBuildingItem.GetBuilding.GetType.OnlyEstatesCanBuild))]"
+					size = { 100% 100% }
+					ignore_layout = yes
+					action_tooltip = {
+						click_type = left
+						click_mode = single
+						title = "OPEN_PROD_METHOD_BUILDING_ITEM_LOCATION"
+						enabled = "[LocationBuildingItem.IsPlayerBuilding]"
+						on_action = "[LocationBuildingItem.OpenBuildingView]"
+					}
+					action_tooltip = {
+						click_type = right
+						click_mode = single
+						title = "BUILD_BUILDING_FROM_LOCATION"
+						on_action = "[SelectLocationToBuildDefault(LocationBuildingItem.GetBuilding.GetType)]"
+					}
+					enabled = "[LocationBuildingItem.IsPlayerBuilding]"
+
+					datacontext = "[LocationBuildingItem.GetBuilding]"
+					tooltipwidget = {
+						using = Building_tooltip
+					}
+				}
+				card_header_button_04 = {
+					size = { 100% 100% }
+					ignore_layout = yes
+					visible = "[Or(Not(LocationBuildingItem.IsPlayerBuilding), Building.GetType.OnlyEstatesCanBuild)]"
+					enabled = no
+					datacontext = "[LocationBuildingItem.GetBuilding]"
+					tooltipwidget = {
+						using = Building_tooltip
+					}
+				}
+				widget = {
+					size = { 100% 100% }
+					visible = "[And3(LocationBuildingItem.GetBuilding.GetType.IsProducing, LocationBuildingItem.IsPlayerBuilding, Not(LocationBuildingItem.GetBuilding.GetType.OnlyEstatesCanBuild))]"
+					card_header_button_04 = {
+						size = { 100% 100% }
+						ignore_layout = yes
+						datacontext_from_model = { datamodel = "[LocationBuildingItem.GetBuilding.GetProductionMethods]" index = 0 }
+						datacontext = "[LocationBuildingItem.GetBuilding]"
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							title = "OPEN_PROD_METHOD_BUILDING_ITEM_LOCATION"
+							enabled = "[LocationBuildingItem.IsPlayerBuilding]"
+							on_action = "[LocationBuildingItem.OpenBuildingView]"
+						}
+	
+						action_tooltip = {
+							click_type = right
+							click_mode = single
+							title = "BUILD_BUILDING_FROM_LOCATION"
+							on_action = "[SelectLocationToBuildDefault(LocationBuildingItem.GetBuilding.GetType)]"
+						}
+						
+						tooltipwidget = {
+							using = Building_tooltip
+						}
+					}
+				}
+
+				# icon piechart
+				widget = {
+					block "circle_size" {
+						parentanchor = center
+						widgetanchor = hcenter|bottom
+						position = {0 2}
+						size = {77% 77%}
+					}
+					icon = {
+						visible = "[Not(LocationBuildingItem.IsConstruction)]"
+						size = { 80% 80% }
+						parentanchor = center
+						position = { 0 -1}
+						texture = "[GetBuildingIcon(LocationBuildingItem.GetBuilding.GetType)]"
+						glow = {
+							name = "drop_shadow"
+							glow_radius = 2
+							color = {0.0 0.0 0.0 1.0}
+							alpha = 0.6
+						}
+					}
+					piechart = {
+						visible = "[LocationBuildingItem.IsConstruction]"
+						parentanchor = center
+						size = { 85% 85% }
+						using = piechart_angles
+						datacontext = "[LocationBuildingItem.GetConstruction]"
+						tooltipwidget = {
+							using = Construction_tooltip
+						}
+	
+						icon = {
+							texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+							size = { 97% 97% }
+							parentanchor = center
+							color = { 0 0 0 1 }
+						}
+	
+						pieslice_no_highlight = {
+							texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+							value = "[LocationBuildingItem.GetConstruction.GetProgress]"
+							color = { 0.01 0.6 0.9 1 }
+							alpha = 0.8
+						}
+	
+						pieslice_no_highlight = {
+							texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+							value = "[Subtract_float('(float)100.0', LocationBuildingItem.GetConstruction.GetProgress)]"
+							color = { 0.0 0.1 0.1 1 }
+							alpha = 0.8
+						}
+	
+						icon = {
+							size = { 17 17 }
+							parentanchor = center
+							texture = "[GetBuildingIcon(LocationBuildingItem.GetBuilding.GetType)]"
+						}
+					}
+
+					icon = {
+						parentanchor = bottom|left
+						using = warning_icon_texture
+						size = { 12 12 }
+						position = { 0 -2 }
+						visible = "[LocationBuildingItem.IsLackingInput]"
+						datacontext = "[LocationBuildingItem.GetBuilding]"
+						using = bg_circle
+					}
+					
+					icon = {
+						parentanchor = bottom|left
+						texture = "gfx/interface/icons/alerts_icons/unprofitable.dds"
+						size = { 12 12 }
+						position = { 0 -2 }
+						visible = "[And3(
+							LessThan_CFixedPoint(Building.GetProfit, '(CFixedPoint)0'), 
+							Not(Building.IsSubsidized),
+							Not(LocationBuildingItem.IsLackingInput)
+						)]"
+						datacontext = "[LocationBuildingItem.GetBuilding]"
+						using = bg_circle
+					}		
+
+					icon = {
+						parentanchor = bottom|left
+						texture = "gfx/interface/icons/flat_icons/lock.dds"
+						modify_texture = {
+							using = color_yellow_texture
+							alpha = 1.4
+						}
+						modify_texture = {
+							using = color_new_gold_texture
+							alpha = 0.7
+						}
+						modify_texture = {
+							using = color_black_texture
+							blend_mode = multiply
+							alpha = 0.6
+						}
+						size = { 12 12 }
+						position = { 0 -2 }
+						visible = "[Not(Building.IsOpen)]"
+						datacontext = "[LocationBuildingItem.GetBuilding]"
+						using = bg_circle
+					}
+					
+					using = bg_circle_tile_shadow
+					background = {
+						texture = "gfx/interface/component_tiles/hud_corners/circle_background.dds"
+						texture_density = 2
+						modify_texture = {
+							using = color_dark_blue_texture
+							blend_mode = multiply
+						}
+						modify_texture = {
+							color = "[LocationBuildingItem.GetBuilding.GetType.GetPopType.GetColor]"
+							# blend_mode = multiply
+							alpha = 0.8
+						}
+					}
+					background = {
+						texture = "gfx/interface/component_tiles/hud_corners/circle_frame.dds"
+						
+						modify_texture = {
+							using = color_new_gold_texture
+						}
+						modify_texture = {
+							using = overlay_stone_texture
+							blend_mode = overlay
+							alpha = 0.3
+						}
+						modify_texture = {
+							using = overlay_window_texture
+							blend_mode = overlay
+							alpha = 0.3
+						}
+					}
+				}
+			}
+				
+			# plus minus
+			widget = {
+				layoutpolicy_horizontal = expanding
+				block "square_icon_out_size_minus" {
+					size = { -1 12 }
+				}
+				hbox = {
+					spacing = -1
+					flag_estate_building_card = {
+						spacing = -1
+						datacontext = "[LocationBuildingItem.GetBuilding.GetType]"
+						datacontext = "[LocationBuildingItem.GetBuilding]"
+						blockoverride "flag_estate_building_card_extra"{
+							button_square_minus = {
+								layoutpolicy_horizontal = expanding
+								block "square_icon_out_size_minus" {
+									size = { -1 12 }
+								}
+								datacontext = "[LocationBuildingItem.GetBuilding]"
+								enabled = "[Or(And(Not(LocationBuildingItem.IsBuildingUnderConstruction), LocationBuildingItem.CanDestroy), And(LocationBuildingItem.IsBuildingUnderConstruction, LocationBuildingItem.CanDequeue))]"
+								action_tooltip = {
+									click_mode = confirm
+									click_type = left
+									datacontext = "[Building.GetType]"
+									title = "L_DESTROY_BUILDING_ACTION"
+									visible = "[Not(LocationBuildingItem.IsBuildingUnderConstruction)]"
+									enabled = "[LocationBuildingItem.CanDestroy]"
+									description = "[LocationBuildingItem.CanDestroyDesc]"
+									on_action = "[LocationBuildingItem.Destroy]"
+									on_action = "[PlayAudioEffect('UI_action_building_destroy')]"
+								}
+			
+								action_tooltip = {
+									click_mode = single
+									click_type = left
+									title = "DEQUEUE_BUILDING_ACTION"
+									visible = "[LocationBuildingItem.IsBuildingUnderConstruction]"
+									enabled = "[LocationBuildingItem.CanDequeue]"
+									description = "[LocationBuildingItem.CanDequeueDesc]"
+									on_action = "[LocationBuildingItem.Dequeue]"
+								}
+								tooltipwidget = {
+									using = destroy_building_in_location_tt
+								}
+								blockoverride "square_icon_size" {
+									size = {10 10}
+								}
+							}
+						}
+						blockoverride "flag_estate_building_card_flag_size" {
+							block "tooltip_flag_estate_building_card_flag_size" {
+								size = {19 12}
+							}
+						}
+						blockoverride "flag_estate_building_card_estate_widget_size" {
+							block "square_icon_out_size_minus" {
+								size = { -1 12 }
+							}
+						}
+						blockoverride "flag_estate_building_card_estate_icon_size" {
+							block "tooltip_flag_estate_building_card_estate_icon_size" {
+								size = { 13 13 }
+							}
+						}
+					}
+	
+					button_square_plus = {
+						layoutpolicy_horizontal = expanding
+						block "square_icon_out_size_plus" {
+							size = { -1 12 }
+						}
+						blockoverride "square_icon_size" {
+							size = {10 10}
+						}
+						visible = "[And3(Not(LocationBuildingItem.GetBuilding.CanPlayerUpgrade), Not(LocationBuildingItem.GetBuilding.GetType.IsForeign), Not(Building.GetType.OnlyEstatesCanBuild))]"
+						datacontext = "[LocationBuildingItem.GetBuilding]"
+						datacontext = "[LocationBuildingItem.GetBuilding.GetType]"
+						datacontext = "[LocationBuildingItem.GetBuilding.GetLocation]"
+						enabled = "[LocationBuildingItem.CanExpandBuilding]"
+						action_tooltip = {
+							click_mode = single
+							click_type = left
+							click_modifier = default
+							title = "CONSTRUCT_BUILDING_BUTTON"
+							description = "[LocationBuildingItem.GetExpandBuildingInfo]"
+							enabled = "[LocationBuildingItem.CanExpandBuilding]"
+	
+							on_action = "[LocationBuildingItem.ExpandBuilding]"
+						}
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							click_modifier = ctrl
+	
+							title = "BUILDING_IN_LOCATION_ACTION_CTRL"
+							description = "[LocationBuildingItem.GetExpandBuildingInfo]"
+							enabled = "[LocationBuildingItem.CanExpandBuilding]"
+	
+							on_action = "[ExpandBuildingCtrl(LocationBuildingItem.GetBuilding.Self)]"
+						}
+	
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							click_modifier = shift
+	
+							title = "BUILDING_IN_LOCATION_ACTION_SHIFT"
+							description = "[LocationBuildingItem.GetExpandBuildingInfo]"
+							enabled = "[LocationBuildingItem.CanExpandBuilding]"
+	
+							on_action = "[ExpandBuildingShift(LocationBuildingItem.GetBuilding.Self)]"
+						}
+						tooltipwidget = { using = construct_building_in_location_tt }
+					}
+
+					button_square_plus = {
+						layoutpolicy_horizontal = expanding
+						size = { -1 12 }
+						blockoverride "square_icon_size" {
+							size = {10 10}
+						}
+						blockoverride "plusminus_icon" {
+							texture = "gfx/interface/buttons/flats/upgrade_button2.dds"
+						}
+						visible = "[And3(LocationBuildingItem.GetBuilding.CanPlayerUpgrade, Not(LocationBuildingItem.GetBuilding.GetType.IsForeign), Not(LocationBuildingItem.GetBuilding.GetType.OnlyEstatesCanBuild))]"
+						datacontext = "[LocationBuildingItem.GetBuilding.GetType.GetNextReplaced(Player.Self)]"
+						datacontext = "[LocationBuildingItem.GetBuilding.GetLocation]"
+						enabled = "[CanUpgradeToBuilding(BuildingType.Self, Location.Self)]"
+						action_tooltip = {
+							click_mode = single
+							click_type = left
+							click_modifier = default
+							title = "UPGRADE_BUILDING_ACTION"
+							enabled = "[CanUpgradeToBuilding(BuildingType.Self, Location.Self)]"
+							description = "[CanUpgradeToBuildingInfo(BuildingType.Self, Location.Self)]"
+							cost = "[GetBuildOrExpandBuildingCostValue(BuildingType.Self, Location.Self)]"
+							on_action = "[UpgradeBuildingDefault(BuildingType.Self, Location.Self)]"
+						}
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							click_modifier = ctrl
+
+							title = "UPGRADE_BUILDING_ACTION_CTRL"
+							cost = "[GetBuildOrExpandBuildingCostValue(BuildingType.Self, Location.Self)]"
+							description = "[CanUpgradeToBuildingInfo(BuildingType.Self, Location.Self)]"
+							on_action = "[UpgradeBuildingCtrl(BuildingType.Self, Location.Self)]"
+							enabled = "[CanUpgradeToBuilding(BuildingType.Self, Location.Self)]"
+						}
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							click_modifier = shift
+
+							title = "UPGRADE_BUILDING_ACTION_SHIFT"
+							cost = "[GetBuildOrExpandBuildingCostValue(BuildingType.Self, Location.Self)]"
+							description = "[CanUpgradeToBuildingInfo(BuildingType.Self, Location.Self)]"
+							on_action = "[UpgradeBuildingShift(BuildingType.Self, Location.Self)]"
+							enabled = "[CanUpgradeToBuilding(BuildingType.Self, Location.Self)]"
+						}
+
+						tooltipwidget = {
+							using = construct_building_in_location_tt
+						}
+					}
+				}
+			}
+		}
+	}
+
+	type location_buildings_tooltip = flowcontainer {
+		wrap_count = 6
+		ignoreinvisible = yes
+		parentanchor = center
+		layoutpolicy_horizontal = expanding
+		margin = { 5 5 }
+
+		block "location_buildings_tooltip_datamodel" {
+			datamodel = "[LocationView.GetLocationBuildings(PopType.Self)]"
+		}
+		
+		item = {
+			widget = {
+				size = { 65 89 }
+				block "location_buildings_tooltip_items_visible" {
+					visible = "[And(LocationBuildingItem.IsBuildingForPopType(PopType.Self), LocationBuildingItem.GetBuilding.GetType.IsForeign)]"
+				}
+				widget = {
+					size = { 63 85 }
+					parentanchor = center
+					# buildings
+					datacontext = "[LocationBuildingItem.GetBuilding]"
+					datacontext = "[LocationBuildingItem.GetBuilding.GetType]"
+					row_building_card = {
+						blockoverride  "circle_size" {
+							parentanchor = center
+							widgetanchor = hcenter|bottom
+							position = {0 4}
+							size = {43 43}
+						}
+						blockoverride "row_building_card_frame_size" {
+							size = { 89% 85% }
+							parentanchor = center
+							position = {0 0}
+						}
+					
+						blockoverride "number_size" {
+							size = { -1 20 }
+						}
+						blockoverride "margin_size" {
+							margin_top = 30
+						}
+						blockoverride "square_icon_out_size_plus" {
+							size = { -1 18 }
+						}	
+						blockoverride "square_icon_out_size_minus" {
+							size = { -1 18 }
+						}
+						blockoverride "tooltip_flag_estate_building_card_flag_size" {
+							size = {28 18}
+						}
+						blockoverride "tooltip_flag_estate_building_card_estate_icon_size" {
+							size = { 19 19 }
+						}
+					}
+				}
+			}
+		}
+	}
+
+	type garrison_sortie_button = header_action_button_left {		
+		blockoverride "icon_texture" {
+			texture = "gfx/interface/buttons/flats/garrison.dds"
+		}
+		blockoverride "button_icon_stretch_sprite" {}
+		blockoverride "header_button_frame_inner" {visible = no}
+		blockoverride "header_button_icon_size" { size = { 25 25 } }
+		blockoverride "header_button_text_layout" {}
+		size = { 25 25 }
+		title = "GARRISON_SORTIE_TT"
+		actor = "[GetPlayer]"
+		parameter = {
+			parameter_name = "target"
+			parameter_value = "[Siege.MakeScope]"
+		}
+		left_click_and_hold_action = { action_name = "garrison_sortie" }
+	}
+
+	type location_card = hbox {
+		using = layoutpolicy_expanding
+
+		# LOCATION
+		hbox = {
+			using = layoutpolicy_expanding
+
+			vbox = {
+				using = layoutpolicy_expanding
+				block "location_card_margins" {
+					margin = {5 5}
+					margin_right = 5
+				}	
+
+				# TOP CONTENT
+				hbox = {
+					using = layoutpolicy_expanding
+					# layoutstretchfactor_vertical = 5
+					margin_left = 1
+					spacing = 2 
+					
+					# UPGRADE RANK
+					widget = {
+						size = { 33 33 }
+						# visible = "[Or(Location.CanUpgradeRank, Location.CanDowngradeRank)]"
+						button_regular = {
+							size = { 100% 100% }
+							position = {0 1}
+
+							action_tooltip = {
+								click_type = left
+								click_mode = confirm
+								enabled = "[Location.CanUpgradeRank]"
+								title = "[Location.GetUpgradeRankName]"
+								cost = "[Location.GetUpgradeRankPrice]"
+								description = "[Location.GetUpgradeRankDescription]"
+								effects = "[Location.GetUpgradeRankEffects]"
+								conditions = "[Location.GetUpgradeRankConditions]"
+								on_action = "[UpgradeLocationRank(Location.Self)]"
+							}
+
+							action_tooltip = {
+								click_type = right
+								click_mode = confirm
+								enabled = "[Location.CanDowngradeRank]"
+								title = "location_downgrade"
+								cost = "[Location.GetDowngradeRankPrice]"
+								description = "[Location.GetDowngradeRankDescription]"
+								effects = "[Location.GetDowngradeRankEffects]"
+								conditions = "[Location.GetDowngradeRankConditions]"
+								on_action = "[DowngradeLocationRank(Location.Self)]"
+							}
+
+							enabled = "[Or(Location.CanUpgradeRank, Location.CanDowngradeRank)]"
+
+							tooltipwidget = {
+								using = location_rank_tooltip
+								blockoverride "location_rank_tooltip_button" {
+									TooltipBlockList = {
+										visible = "[Not(StringIsEmpty(Location.GetUpgradeRankPriceBreakdown))]"
+										textcontext = "[Location.GetUpgradeRankPriceBreakdown]"
+									}
+								}
+							}
+						}
+
+						icon = {
+							size = { 20 20 }
+							parentanchor = center
+							position = {1 0}
+							texture = "[Location.GetRankIcon]"
+						}
+					}
+
+					hbox = {
+						# INTEGRATION/CORE
+						widget = {
+							size = { 31 31 }
+							visible = "[Location.HasOwner]"
+
+							# NOT INTEGRATED
+							header_button_left = {
+								visible = "[And(Not(Location.IsOccupied), Not(Location.IsIntegrated))]"
+								size = { 31 31 }
+								blockoverride "button_icon_stretch_sprite" {}
+								blockoverride "header_button_frame_inner" {visible = no}
+								blockoverride "header_button_icon_size" { size = { 31 31 } }
+								blockoverride "header_button_text_layout" {}
+								
+								blockoverride "icon_texture" {
+									texture = "[GetIntegrationLevelIcon(Location.GetIntegrationLevel)]"
+									size = {55% 55%}
+								}
+								action_tooltip = {
+									click_type = left
+									click_mode = single
+									title = "AUTOMATED_SYSTEM_CABINET_CLICK"
+									on_action = "[OpenLateralViewWithParams('government', 'tabcontent = cabinet')]"
+								}
+								tooltipwidget = {
+									using = location_core_tooltip
+								}
+								
+								# BEING INTEGRATED
+								onclick = "[OpenLateralViewWithParams('government', 'tabcontent = cabinet')]"
+								piechart = {
+									using = bg_circle
+									using = bg_circle_piechart
+									using = piechart_angles
+									size = { 20 20 }
+									parentanchor = center
+									visible = "[And(Not(Location.IsOccupied), And(Location.HasOwner, Location.IsCurrentlyBeingIntegrated))]"
+	
+									pieslice = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+										value = "[Location.GetIntegrationProgressFloat]"
+										color = { 1 1 1 1 }
+										alwaystransparent = yes
+									}
+	
+									pieslice = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+										value = "[Subtract_float('(float)100.0', Location.GetIntegrationProgressFloat)]"
+										color = { 1 1 1 1 }
+										alwaystransparent = yes
+									}
+	
+									icon = {
+										size = { 58% 58% }
+										parentanchor = center
+										texture = "[GetIntegrationLevelIcon(Location.GetIntegrationLevel)]"
+										alwaystransparent = yes
+									}								
+								}
+							}
+							
+
+							# INTEGRATED
+							icon = {
+								visible = "[Or(Location.IsIntegrated, And(Not(Location.GetOwner.IsPlayer), Not(Location.IsCurrentlyBeingIntegrated)))]"
+								size = { 25 25 }
+								parentanchor = center
+								texture = "[GetIntegrationLevelIcon(Location.GetIntegrationLevel)]"
+								alwaystransparent = no
+
+								tooltipwidget = {
+									using = location_core_tooltip
+								}
+
+								glow = {
+									name = "drop_shadow"
+									glow_radius = 3
+									color = {0.0 0.0 0.0 1.0}
+									alpha = 0.3
+								}
+							}
+						}
+					}
+
+					hbox = {
+						layoutpolicy_horizontal = expanding
+						using = bg_card_header_01
+						blockoverride "header_pattern_texture_density" {texture_density = 2.4}
+						blockoverride "header_pattern_alpha" { alpha = 0.5 }
+						blockoverride "bg_card_header_01_bg" {
+							background = {
+								using = bg_card_header_01_default
+								blockoverride "header_color" {
+									using = color_black_texture
+
+									modify_texture = {
+										using = overlay_cloth_texture
+										blend_mode = overlay
+										alpha = 0.1
+									}
+									using = location_side_color
+								}
+							}
+						}
+
+						# LOCATION BUTTON
+						card_header_button_04 = {
+							layoutpolicy_horizontal = expanding
+							size = {-1 31}
+
+							using = location_background
+
+							block "location_card_main_action_button"{
+								action_tooltip = {
+									click_type = left
+									click_mode = single
+									title = "GO_TO_LOCATION"
+									on_action = "[ShowLocation(Location.Self)]"
+								}
+
+								action_tooltip = {
+									click_type = right
+									click_mode = single
+
+									cursor = "location_menu"
+									title = "CLICK_ACTION_LOCATION_CONTEXT_MENU"
+									on_action = "[PdxGuiWidget.ToggleContextMenu]"
+								}
+								onmousehierarchyenter = "[PdxGuiWidget.SetHighlightLocation(Location.Self)]"
+
+								# block "location_card_title_tooltip" {
+									tooltipwidget = {
+										using = location_tooltip_alt
+									}
+								# }
+								contextmenu_widget = {
+									LocationContextMenu = {}
+								}
+							}
+
+							hbox = {
+								margin = {5 0}
+								spacing = 5
+								using = bg_black_fade_horizontal
+
+								text_single = {
+									using = layoutpolicy_expanding
+									autoresize = no
+									align = nobaseline
+									text = "[Location.GetNameWithNoTooltip]"
+								}
+
+								# block "location_card_topcontent_extra" {}
+
+								# STATUS
+								hbox = {
+									margin_left = 5
+									spacing = 5
+									visible = "[Or(Location.HasCombat,Location.IsOccupied)]"
+									# IS OCCUPIED
+									hbox = {
+										spacing = 4
+										visible = "[Location.IsOccupied]"
+										text_single = {
+											align = nobaseline
+											maximumsize = { 80 -1 }
+											text = "game_concept_occupied"
+											default_format = "#explanation_link"
+										}
+
+										country_flag_small = {
+											size = { 36 24 }
+											datacontext = "[Location.GetController]"
+										}
+									}
+									# BATTLE
+									widget = {
+										size = { 20 20 }
+										visible = "[Location.HasCombat]"
+										datacontext = "[Location.GetCombat]"
+										CombatProgress = {
+											size = {100% 100%}
+										}
+										tooltipwidget = {
+											using = Combat_tooltip
+										}
+									}
+								}
+							}
+						}
+					}
+
+					# RIGHT BUTTONS
+					hbox = {
+						margin = { 3 0 }
+						spacing = 2
+
+						# FORT LEVEL & GARRISON
+						card_header_button_04 = {
+							onmousehierarchyenter = "[PdxGuiWidget.SetHighlightFort(Location.Self)]"
+							size = {160 31}
+							visible = "[Not(
+							And4(Location.IsOccupied, Not(Location.HasSiege), Not(IsLateralViewOpened('select_interaction_target')), Or(Location.GetController.IsPlayer, Location.GetController.GetDiplomacy.IsSubjectOf(GetPlayer))))]"
+
+							using = location_background
+
+							tooltipwidget = {
+								using = Garrison_tooltip
+							}
+							action_tooltip = {
+								click_type = left
+								click_mode = single
+								title = "GARRISON_TOOLTIP_LEFT_CLICK"
+								on_action = "[ShowFortProductionInLocation(Location.Self)]"
+								visible = "[Location.GetOwner.IsPlayer]"
+							}
+							enabled = "[Location.GetOwner.IsPlayer]"
+
+							hbox = {
+								margin = {6 0}
+								using = location_fort_status
+							}
+						}
+
+						# TRANSFER OCCUPATION
+						card_header_button_04 = {
+							size = {160 31}
+							visible = "[And4(Location.IsOccupied, Not(Location.HasSiege), Not(IsLateralViewOpened('select_interaction_target')), Or(Location.GetController.IsPlayer, Location.GetController.GetDiplomacy.IsSubjectOf(GetPlayer)))]"
+
+							using = location_background
+
+							tooltipwidget = {
+								SimpleContextualTooltipType = {
+									blockoverride "title_icon" {
+										icon = {
+											using = tooltip_title_icon_size
+											texture = "gfx/interface/icons/flat_icons/declare_war/transfer_occupation.dds"
+										}
+									}
+									lowpriotextcontext = "[Location.GetTransferOccupationTooltip]"
+								}
+							}
+
+							enabled = "[Location.CanTransferOccupation]"
+							action_tooltip = {
+								click_type = left
+								click_mode = single
+								title = "TRANFER_OCC_TITLE_ACTION"
+								enabled = "[Location.CanTransferOccupation]"
+								on_action = "[ShowTransferOccupation(Location.Self)]"
+							}
+
+							action_tooltip = {
+								click_type = right
+								click_mode = single
+								title = "TRANFER_OCC_PROVINCE_TITLE_ACTION"
+								enabled = "[Location.CanTransferOccupation]"
+								on_action = "[ShowTransferProvinceOccupation(Location.Self)]"
+							}
+
+							hbox = {
+								margin = {6 0}
+								using = location_fort_status
+								blockoverride "location_fort_status_extra" {
+									icon = {
+										size = { 20 20 }
+										texture = "gfx/interface/icons/flat_icons/declare_war/transfer_occupation.dds"
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+
+				# BOTTOM CONTENT
+				hbox = {
+					layoutpolicy_horizontal = expanding
+					margin = { 2 1 }
+					spacing = 1
+
+					# SATISFACTION & POPULATION
+					button_regular = {
+						# layoutpolicy_horizontal = expanding
+						# size = { -1 28 }
+
+						size = { 120 28 }
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							title = "OPEN_PEOPLE_VIEW"
+							on_action = "[ShowCountryPeopleViewWithLocation(Location.GetId, '(bool)yes')]"
+						}
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							click_modifier = shift
+							title = "encourage_migration"
+							on_action = "[ShowSelectCabinetToEncourageMigration(Location.Self)]"
+							enabled = "[IsCabinetActionAllowed('encourage_migration')]"
+							conditions = "[GetCabinetActionTooltip('encourage_migration')]"
+						}
+
+						action_tooltip = {
+							click_type = right
+							click_mode = single
+							click_modifier = shift
+							title = "expel_people"
+							on_action = "[ShowSelectCabinetToExpelPeople(Location.GetProvince)]"
+							enabled = "[And(Or(IsCabinetActionAllowed('expel_people'), IsCabinetActionAllowed('encourage_migration')), Location.GetOwner.IsPlayer)]"
+							conditions = "[GetCabinetActionTooltip('expel_people')]"
+						}
+
+						tooltipwidget = {
+							using = population_location_tooltip
+						}
+
+						hbox = {
+							margin_left = 3
+							spacing = 5
+							widget = {
+								size = { 28 28 }
+								
+
+								tooltipwidget = {
+									using = AverageSatisfaction_tooltip
+								}
+								piechart = {
+									parentanchor = center
+									size = { 25 25 }
+									alwaystransparent = yes
+
+									using = piechart_angles
+
+									pieslice_no_highlight = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+										value = "[FixedPointToFloat(Location.GetAverageSatisfaction)]"
+										color = { 1 1 1 1 }
+										alwaystransparent = yes
+									}
+
+									pieslice_no_highlight = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+										value = "[Subtract_float('(float)1.0', FixedPointToFloat(Location.GetAverageSatisfaction))]"
+										color = { 1 1 1 1 }
+										alwaystransparent = yes
+									}
+
+									hbox = {
+										widget = {
+											using = layoutpolicy_expanding
+											icon = {
+												size = { 61% 61% }
+												parentanchor = center
+												name = "sad face"
+												visible = "[LessThanOrEqualTo_CFixedPoint(Location.GetAverageSatisfaction,'(CFixedPoint)0.25')]"
+												texture = "gfx/interface/icons/flat_icons/sad.dds"
+												texture_density = 2
+											}
+
+											icon = {
+												size = { 61% 61% }
+												parentanchor = center
+												name = "neutral face"
+												visible = "[BetweenInclusiveOfMax_CFixedPoint(Location.GetAverageSatisfaction,'(CFixedPoint)0.25', '(CFixedPoint)0.5')]"
+												texture = "gfx/interface/icons/flat_icons/neutral.dds"
+												texture_density = 2
+											}
+
+											icon = {
+												size = { 61% 61% }
+												parentanchor = center
+												name = "happy face"
+												visible = "[GreaterThan_CFixedPoint(Location.GetAverageSatisfaction,'(CFixedPoint)0.5')]"
+												texture = "gfx/interface/icons/flat_icons/happy.dds"
+												texture_density = 2
+											}
+										}
+									}
+									using = bg_circle_piechart
+								}
+							}
+
+							vbox = {
+								layoutpolicy_horizontal = expanding
+								margin_right = 8
+								margin_bottom = 3
+
+								text_single = {
+									layoutpolicy_horizontal = expanding
+									autoresize = no
+									align = center
+									size = { -1 15 }
+									raw_text = "[Location.GetTotalPopulation]@population!"
+									fontsize = 13
+								}
+
+								progressbar = {
+									layoutpolicy_horizontal = expanding
+									size = { -1 5 }
+									using = progress_bar_green_alt
+									value = "[Location.GetCapacityPercentage]"
+									direction = horizontal
+								}
+							}
+						}
+					}
+
+					# MARKET ACCESS
+					button_regular = {
+						# layoutpolicy_horizontal = expanding
+						# size = { -1 28 }
+						size = { 90 28 }
+
+						datacontext = "[Location.GetMarket]"
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							title = "OPEN_MARKET"
+							on_action = "[ShowMarket(Market.Self)]"
+						}
+
+						action_tooltip = {
+							click_type = right
+							click_mode = confirm
+							title = "LOC_VIEW_CREATE_MARKET"
+							visible = "[Not(Location.IsMarketCenter)]"
+							enabled = "[CanCreateMarketInLocation(Location.Self)]"
+							on_action = "[CreateMarketInLocation(Location.Self)]"
+							conditions = "[CanCreateMarketInLocationTooltip(Location.Self)]"
+						}
+
+						action_tooltip = {
+							click_type = right
+							click_mode = confirm
+							title = "LOC_VIEW_DESTROY_MARKET"
+							visible = "[Location.IsMarketCenter]"
+							enabled = "[CanDestroyMarketInLocation(Location.Self)]"
+							on_action = "[DestroyMarketInLocation(Location.Self)]"
+							conditions = "[CanDestroyMarketInLocationTooltip(Location.Self)]"
+						}
+
+						# action_tooltip = {
+						# 	click_type = right
+						# 	click_mode = single
+
+						# 	cursor = "market_menu"
+						# 	title = "CLICK_ACTION_MARKET_CONTEXT_MENU"
+						# 	on_action = "[PdxGuiWidget.ToggleContextMenu]"
+						# }
+
+						# contextmenu_widget = {
+						# 	MarketContextMenu = {}
+						# }
+
+						onmousehierarchyenter = "[PdxGuiWidget.SetHighlightMarket(Market.Self)]"
+						ondoubleclick = "[PanToLocation(Market.GetCenterLocation)]"
+
+						tooltipwidget = {
+							using = location_market_tooltip
+						}
+
+						hbox = {
+							hbox = {
+								layoutpolicy_horizontal = expanding
+								margin_right = 5
+								margin_left = 3
+								spacing = 3
+								widget = {
+									size = {28 28}
+									piechart = {
+										parentanchor = center
+										size = { 25 25 }
+										alwaystransparent = yes
+										using = piechart_angles
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+											value = "[FixedPointToFloat(Location.GetMarketAccess)]"
+											color = { 1 1 1 1 }
+											alwaystransparent = yes
+										}
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+											value = "[Subtract_float('(float)1.0', FixedPointToFloat(Location.GetMarketAccess))]"
+											color = { 1 1 1 1 }
+											alwaystransparent = yes
+										}
+
+										icon = {
+											size = { 61% 61% }
+											parentanchor = center
+											texture = "gfx/interface/icons/location_icons/market.dds"
+										}
+
+										using = bg_circle_piechart
+									}
+								}
+
+								text_single = {
+									align = left|nobaseline
+									layoutpolicy_horizontal = expanding
+									autoresize = no
+									fontsize = 14
+									raw_text = "[Location.GetMarketAccess|0%]"
+								}
+							}
+						}
+					}
+
+					# CONTROL
+					button_regular = {
+						# layoutpolicy_horizontal = expanding
+						# size = { -1 28 }
+
+						size = { 90 28 }
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							title = "increase_control_province"
+							on_action = "[ShowSelectCabinetToIncreaseControl(Location.GetProvince)]"
+							enabled = "[And(IsCabinetActionAllowed('increase_control_province'), Location.GetOwner.IsPlayer)]"
+							conditions = "[GetCabinetActionTooltip('increase_control_province')]"
+						}
+						action_tooltip = {
+							visible = "[And(IsCabinetActionAllowed('increase_control_province'), Location.GetOwner.IsPlayer)]"
+							click_modifier = shift
+							click_type = left
+							title = "OPEN_HINT"
+							on_action = "[OpenLateralViewWithParams('hints', 'selected_hint = hint_control')]"
+						}
+						enabled = "[And(IsCabinetActionAllowed('increase_control_province'), Location.GetOwner.IsPlayer)]"
+
+						tooltipwidget = {
+							using = location_control_tooltip
+							blockoverride "shift_left_extra" {
+								replacement_shift_item = {}
+							}
+						}
+
+						hbox = {
+							hbox = {
+								layoutpolicy_horizontal = expanding
+								margin_right = 5
+								margin_left = 3
+								spacing = 3
+								widget = {
+									size = {28 28}
+									piechart = {
+										parentanchor = center
+										size = { 25 25 }
+										alwaystransparent = yes
+										using = piechart_angles
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+											value = "[FixedPointToFloat(Location.GetControl)]"
+											color = { 1 1 1 1 }
+											alwaystransparent = yes
+										}
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+											value = "[Subtract_float('(float)1.0', FixedPointToFloat(Location.GetControl))]"
+											color = { 1 1 1 1 }
+											alwaystransparent = yes
+										}
+
+										icon = {
+											size = { 61% 61% }
+											parentanchor = center
+											texture = "gfx/interface/icons/location_icons/control.dds"
+										}
+
+										using = bg_circle_piechart
+									}
+								}
+
+								text_single = {
+									align = left|nobaseline
+									layoutpolicy_horizontal = expanding
+									autoresize = no
+									fontsize = 14
+									raw_text = "[Location.GetControl|0%]"
+								}
+							}
+						}
+					}
+
+					# RGO
+					button_regular = {
+						# layoutpolicy_horizontal = expanding
+						# size = { -1 28 }
+						size = { 90 28 }
+						enabled = "[Location.GetOwner.IsPlayer]"
+
+						tooltipwidget = {
+							using = location_rgo_button_tooltip
+						}
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+
+							title = "MANAGE_LOCATION_BUILDINGS"
+							on_action = "[GetScriptedGui('mnt_set_rgo_buildings_visible_on').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
+							on_action = "[OpenLateralViewWithParams('location_production', 'display = lists')]"
+							on_action = "[OpenLateralViewWithFilter('location_production', Location.GetRawMaterial.GetKey)]"
+							on_action = "[ShowLocationProductionView(Location.GetId, '(bool)no')]"
+						}
+
+						hbox = {
+							hbox = {
+								layoutpolicy_horizontal = expanding
+								margin_right = 5
+								margin_left = 3
+								spacing = 3
+								widget = {
+									size = {28 28}
+									piechart = {
+										visible = "[GreaterThan_CFixedPoint(Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level'), '(CFixedPoint)0')]"
+										alwaystransparent = yes
+										parentanchor = center
+										size = { 25 25 }
+										using = piechart_angles
+										using = bg_circle_piechart
+										pieslice_no_highlight = {
+											filter_mouse = none
+											alwaystransparent = yes
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+											value = "[Divide_CFixedPoint(Location.MakeScope.ScriptValue('mnt_location_current_rgo_building_level'), Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level'))]"
+											color = { 1 1 1 1 }
+										}
+
+										pieslice_no_highlight = {
+											filter_mouse = none
+											alwaystransparent = yes
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+											value = "[Subtract_float('(float)1.0', FixedPointToFloatPercentageCapped(Divide_CFixedPoint(Location.MakeScope.ScriptValue('mnt_location_current_rgo_building_level'), Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level')), '(bool)yes'))]"
+											color = { 1 1 1 1 }
+										}
+										icon = {
+											size = { 61% 61% }
+											parentanchor = center
+											texture = "[GetGoodsIcon(Location.GetRawMaterial)]"
+										}
+									}
+								}
+
+								text_single = {
+									align = left|nobaseline
+									layoutpolicy_horizontal = expanding
+									autoresize = no
+									fontsize = 14
+									datacontext = "[Location.GetRawMaterial]"
+									raw_text = "[Location.MakeScope.ScriptValue('mnt_location_current_rgo_building_level')|0]/[Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level')|0]"
+								}
+
+								text_single = {
+									visible = no
+									align = left|nobaseline
+									layoutpolicy_horizontal = expanding
+									autoresize = no
+									fontsize = 14
+									datacontext = "[Location.GetRawMaterial]"
+									raw_text = "[Location.MakeScope.ScriptValue('mnt_location_current_rgo_building_level')|0]/[Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level')|0]"
+								}
+							}
+						}
+					}
+
+					# TAX BASE
+					button_regular = {
+						layoutpolicy_horizontal = expanding
+						size = { -1 28 }
+
+						tooltipwidget = {
+							using = location_tax_base_tooltip
+						}
+
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							title = "MANAGE_LOCATION_BUILDINGS"
+							on_action = "[ShowLocationProductionView(Location.GetId, '(bool)no')]"
+							on_action = "[OpenLateralViewWithParams('location_production', 'display = lists')]"
+						}
+
+						hbox = {
+							hbox = {
+								layoutpolicy_horizontal = expanding
+								margin = { 5 0 }
+								margin_left = 3
+								spacing = 4
+								widget = {
+									size = {28 28}
+									# TAX BASE CHART
+									icon_pie_left = {
+										tooltipwidget = {
+											using = location_tax_base_tooltip
+										}
+										blockoverride "PieSize" { size = { 26 26 } }
+										blockoverride "pie_datamodel" {
+											datacontext = "[Location.GetPopulationChart]"
+											datacontext = "[LocationPopulationChart.GetPopsPiechartWidget]"
+											datamodel = "[PopsPiechartWidget.GetTax]"
+										}
+
+										blockoverride "pieslice_item" {
+											pieslice_no_highlight = {
+												texture = "gfx/interface/pie_charts/piechart_alpha.dds"
+												texture_density = 2
+												tooltip_enabled = no
+												value = "[PopTaxItem.GetPercentage]"
+												color = "[PopTaxItem.GetColor]"
+												alpha = 0.99
+												alwaystransparent = yes
+											}
+										}
+										blockoverride "Icon_Size" { size = { 61% 61% } }
+										blockoverride "Icon" {
+											texture = "[GetConceptTexture('wealth')]"
+											texture_density = 2
+											alwaystransparent = yes
+										}
+
+										background = {
+											texture = "gfx/interface/component_tiles/hud_corners/circle_frame.dds"
+											texture_density = 2
+
+											modify_texture = {
+												using = color_gold_texture
+											}
+
+											using = overlay_gold
+										}
+									}
+								}
+
+								text_single = {
+									align = center
+									layoutpolicy_horizontal = expanding
+									size = { -1 17 }
+									autoresize = no
+									fontsize = 14
+									raw_text = "[Location.GetTotalPossibleTaxBase|W2]"
+								}
+
+								# text_single = {
+								# 	align = left|nobaseline
+								# 	layoutpolicy_horizontal = expanding
+								# 	size = {-1 17}
+								# 	autoresize = no
+								# 	fontsize = 14
+								# 	raw_text = "([Location.GetTotalIncome|+=2])"
+								# }
+
+								icon = {
+									size = { 20 20 }
+									texture = "gfx/interface/icons/flat_icons/building_panel/build.dds"
+								}
+								
+							}
+						}
+					}
+
+					expand = {}
+				}
+			}
+		}
+	}
+
+	type army_slot = widget {
+		size = { 80 35 }
+		icon = {
+			size = { 75 28 }
+			parentanchor = center
+			texture = "gfx/interface/buttons/army_builder_button.dds"
+			texture_density = 2
+			spriteType = corneredstretched
+			spriteborder = { 1 11 }
+			frame_grid = {4 1}
+			frame = 4
+			tooltipwidget = {
+				ContextualTooltipType = {
+					blockoverride "title_icon" {
+						icon = {
+							using = tooltip_title_icon_size
+							texture = "gfx/interface/icons/modifier_types/max_regiments_trained_at_same_time.dds"
+						}
+					}
+					blockoverride "title_text" {
+						text = "OUTLINER_CATEGORY_MILITARY_ARMY_RECRUITMENT"
+					}
+
+					blockoverride "concept_link" {
+						raw_text = "[army|e]"
+					}
+					blockoverride "tooltip_content" {
+						TooltipTextBlock = {
+							blockoverride "text" {
+								text = "AVAILABLE_ARMY_SLOT"
+							}									
+						}
+					}
+				}
+			}
+		}
+	}
+
+	type navy_slot = widget {
+		size = { 80 35 }
+		icon = {
+			size = { 75 28 }
+			parentanchor = center
+			texture = "gfx/interface/buttons/army_builder_button.dds"
+			texture_density = 2
+			spriteType = corneredstretched
+			spriteborder = { 1 11 }
+			frame_grid = {4 1}
+			frame = 4
+			tooltipwidget = {
+				ContextualTooltipType = {
+					blockoverride "title_icon" {
+						icon = {
+							using = tooltip_title_icon_size
+							texture = "gfx/interface/icons/modifier_types/max_ships_built_at_same_time.dds"
+						}
+					}
+					blockoverride "title_text" {
+						text = "OUTLINER_CATEGORY_MILITARY_NAVY_RECRUITMENT"
+					}
+
+					blockoverride "concept_link" {
+						raw_text = "[navy|e]"
+					}
+					blockoverride "tooltip_content" {
+						TooltipTextBlock = {
+							blockoverride "text" {
+								text = "AVAILABLE_NAVY_SLOT"
+							}									
+						}
+					}
+				}
+			}
+		}
+	}
+		
+	type location_card_right_buttons = hbox {
+		layoutpolicy_vertical = expanding
+		margin = {5 5}
+		using = bg_cabinet_card_frame
+		spacing = 2
+
+		# block "location_filter_buttons" {
+			vbox = {
+				layoutpolicy_vertical = expanding
+				# block "location_filter_spacing" {
+					spacing = 3
+				# }
+
+				# PREV LOCATION
+				button = {
+					size = { 19 19 }
+					texture = "gfx/interface/buttons/up_button_alt.dds"
+					texture_density = 2
+					enabled = "[CanSelectPrevRelevantLocation(Location.Self)]"
+
+					modify_texture = {
+						using = color_new_gold_texture
+						blend_mode = add
+						alpha = 1
+					}
+					modify_texture = {
+						using = overlay_stone_texture
+						blend_mode = overlay
+						alpha = 1
+					}
+					background = {
+						texture = "gfx/interface/buttons/bg_button_light.dds"
+						texture_density = 2
+						modify_texture = {
+							using = color_intense_brown_texture
+							blend_mode = add
+						}
+						modify_texture = {
+							using = color_dark_brown_texture
+							blend_mode = multiply
+							alpha = 0.8
+						}
+					}
+					tooltipwidget = { BasicFunctionalTooltip = {} }
+
+					block "location_filter_prev_button" {
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							enabled = "[CanSelectPrevRelevantLocation(Location.Self)]"
+							title = "SCROLL_UP_LOCATION_FILTER"
+							on_action = "[ShowLocation(GetPrevRelevantLocation(Location.Self).Self)]"
+						}
+					}
+				}
+
+				block "location_filter_middle_button" {}
+
+				# NEXT LOCATION
+				button = {
+					size = { 19 19 }
+					texture = "gfx/interface/buttons/up_button_alt.dds"
+					mirror = vertical
+					texture_density = 2
+					enabled = "[CanSelectNextRelevantLocation(Location.Self)]"
+
+					modify_texture = {
+						using = color_new_gold_texture
+						blend_mode = add
+						alpha = 1
+					}
+					modify_texture = {
+						using = overlay_stone_texture
+						blend_mode = overlay
+						alpha = 1
+					}
+					background = {
+						texture = "gfx/interface/buttons/bg_button_light.dds"
+						texture_density = 2
+						modify_texture = {
+							using = color_intense_brown_texture
+							blend_mode = add
+						}
+						modify_texture = {
+							using = color_dark_brown_texture
+							blend_mode = multiply
+							alpha = 0.8
+						}
+					}
+					tooltipwidget = { BasicFunctionalTooltip = {} }
+
+					block "location_filter_next_button" {
+						action_tooltip = {
+							click_type = left
+							click_mode = single
+							enabled = "[CanSelectNextRelevantLocation(Location.Self)]"
+							title = "SCROLL_DOWN_LOCATION_FILTER"
+							on_action = "[ShowLocation(GetNextRelevantLocation(Location.Self).Self)]"
+						}
+					}
+				}
+			}
+		# }
+	}
+
+	type location_conditions_item = header_paper_card_horizontal {
+		blockoverride "header_paper_card_size" {
+			block "location_conditions_item_size" {
+				size = { -1 45 }
+			}
+		}
+		layoutpolicy_horizontal = expanding
+
+		block "location_conditions_card_visible" {
+			visible = yes
+		}
+
+		using = bg_cabinet_card_frame
+
+		blockoverride "header_content" {
+			using = bg_card_header_01
+
+			block "location_conditions_card_header" {
+				widget = {
+					size = { 100% 100% }
+
+					tagtooltip_enabled = yes
+					# block "location_conditions_card_header_tooltip" {
+						tooltip = "[international_organizations|e]"
+					# }
+
+					hbox = {
+						expand = {}
+
+						icon = {
+							size = { 28 28 }
+							# block "location_conditions_card_header_texture" {
+								using = default_texture
+							# }
+							glow = {
+								name = "drop_shadow"
+								glow_radius = 3
+								color = {0.0 0.0 0.0 1.0}
+								alpha = 0.3
+							}
+						}
+
+						expand = {}
+					}
+				}
+			}
+		}
+
+		# RIGHT
+		blockoverride "bottom_content" {
+			hbox = {
+				using = bg_corner_flavor
+				blockoverride "corner_flavor_texture" {
+					texture = "gfx/interface/component_decoration/bg_corner_flavor_06.dds"
+					texture_density = 2
+					spriteType = Corneredstretched
+					spriteborder = { 35 35 }
+					alpha = 0.4
+				}
+				blockoverride "corner_flavor_color" {
+					modify_texture = {
+						using = color_bg_blue_texture
+						blend_mode = multiply
+					}
+				}
+				block "location_conditions_card_main_content_margin" {
+					margin = { 5 0 }
+					margin_right = 2
+				}
+				block "location_conditions_card_main_content" {
+					hbox = {
+						layoutpolicy_vertical = expanding
+						block "location_conditions_card_spacing" {
+							spacing = 4
+						}
+						block "location_conditions_card_datamodel" {
+							datamodel = "[DataModelFirst(Player.GetDiplomacy.GetInternationalOrganizations, GetRelationsUILimit)]"
+						}
+						item = {
+							block "location_conditions_card_item" {
+								navigational_button_alt = {
+									parentanchor = left
+									using = bg_circle_alt_brown
+									using = bg_square_tile
+
+									blockoverride "button_icon_stretch_sprite" {}
+
+									blockoverride "button_texture" {
+										texture = "gfx/interface/buttons/navigational_frame.dds"
+										size = { 30 30 }
+									}
+
+									blockoverride "square_extras" {
+										margin = {1 1}
+									}
+
+									blockoverride "icon_texture" {
+										texture = "[InternationalOrganization.GetIcon]"
+										texture_density = 2
+									}
+
+									blockoverride "icon_size" {
+										size = { 80% 80% }
+									}
+
+									onclick = "[OpenInternationalOrganizationView(InternationalOrganization.Self)]"
+									tooltipwidget = {
+										LeftClickButtonTooltip = {
+											blockoverride "onclick_text" {
+												text = "OPEN_IO"
+											}
+										}
+									}
+									visible = "[InternationalOrganization.IsCountryMember(Player.Self)]"
+								}
+							}
+						}
+					}
+				}
+
+				expand = {}
+
+				block "location_conditions_card_extra_text" {
+					text_single = {
+						margin = {5 5}
+						using = Font_Type_Headers
+						raw_text = "+[GetRelationOverUILimit(GetDataModelSize(Player.GetDiplomacy.GetInternationalOrganizations))]"
+						align = nobaseline
+						visible = "[GreaterThan_int32(GetDataModelSize(Player.GetDiplomacy.GetInternationalOrganizations), GetRelationsUILimit)]"
+						tooltipwidget = {
+							using = relation_list_tooltip
+						}
+						using = bg_number_container_bckg
+						blockoverride "number_container_alpha" {
+							alpha = 0.5
+						}
+						blockoverride "number_container_color" {
+							modify_texture = {
+								using = color_bg_blue_texture
+								blend_mode = multiply
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	type army_small_item = widget {
+		size = { 80 35 }
+		block "army_small_item_visible" {
+			visible = "[GreaterThan_int32(ConstructionItem.GetPos, LocationView.GetNumTotalArmyStaticButtons)]"
+		}
+
+		hbox = {
+			widget = {
+				size = { 78 32 }
+				army_builder_button = {
+					size = { 75 30 }
+					parentanchor = center
+					using = army_builder_ui_action
+
+					# blockoverride "flat_sneaky_button_color"{
+					# 	using = color_military_texture
+					# 	alpha = 0.8
+					# }
+
+					datacontext = "[ConstructionItem.GetConstruction]"
+					tooltipwidget = {
+						using = Construction_tooltip
+
+						blockoverride "building_owner" {
+							TooltipTextBlock = {
+								visible = "[Not(CanShowConstructionCancellationDialog(Construction.Self))]"
+								blockoverride "text" {
+									text = "[GetConstructionBuildingOwner(Construction.Self)]"
+								}
+							}
+						}
+					}
+
+					hbox = {
+						spacing = 2
+						expand = {}
+						construction_marker = {
+							size = { 25 25 }
+							blockoverride "button_size" {
+								size = { 15 15 }
+							}
+							blockoverride "piechart_size" {
+								size = { 20 20 }
+							}
+
+							blockoverride "construction_marker_tooltip"{}
+							blockoverride "construction_marker_left_action"{}
+						}
+
+						text_single = {
+							layoutpolicy_horizontal = expanding
+							size = {-1 25}
+							autoresize = no
+							using = Font_Size_Very_Small
+							align = center
+							datacontext = "[ConstructionItem.GetConstruction]"
+							block "army_small_item_value" {
+								text = "CONSTRUCTION_DURATION_DAYS"
+							}
+						}
+						expand = {}
+					}
+				}
+			}
+		}
+	}
+
+	# type colonial_charter_small_item = widget {
+	# 	size = {110 25}
+	# 	datacontext = "[ColonialCharterItem.GetColonialCharter]"
+	# 	using = bg_number_container_bckg
+	# 	blockoverride "number_container_alpha" {
+	# 		alpha = 0.5
+	# 	}
+	# 	blockoverride "number_container_color" {
+	# 		modify_texture = {
+	# 			using = color_bg_blue_texture
+	# 			blend_mode = multiply
+	# 		}
+	# 	}
+	# 	hbox = {
+	# 		piechart = {
+	# 			using = bg_circle
+	# 			size = { 22 22 }
+	# 			using = piechart_angles
+	# 			using = bg_circle_piechart
+	# 			tooltipwidget = {
+	# 				using = colonial_charter_progress_tooltip
+	# 			}
+	# 			icon = {
+	# 				texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+	# 				size = { 97% 97% }
+	# 				parentanchor = center
+	# 				color = { 0 0 0 1 }
+	# 			}
+
+	# 			pieslice_no_highlight = {
+	# 				texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+	# 				value = "[ColonialCharterItem.GetProgress]"
+	# 				color = { 0.3 0.8 0.3 1 }
+	# 				alpha = 0.8
+	# 			}
+
+	# 			pieslice_no_highlight = {
+	# 				texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+	# 				value = "[Subtract_float('(float)100.0', ColonialCharterItem.GetProgress)]"
+	# 				color = { 0.8 0.3 0.3 1 }
+	# 				alpha = 0.8
+	# 			}
+
+	# 			icon = {
+	# 				size = { 61% 61% }
+	# 				parentanchor = center
+	# 				texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+	# 			}
+	# 		}
+
+	# 		country_flag_small = {
+	# 			datacontext = "[ColonialCharterItem.GetColonialCharter.GetOwner]"
+	# 		}
+
+	# 		text_single = {
+	# 			layoutpolicy_vertical = expanding
+	# 			size = { 40 -1 }
+	# 			autoresize = no
+	# 			align = center|nobaseline
+	# 			raw_text = "[ColonialCharterItem.GetColonialCharter.GetMonthlyMigration]@population!"
+	# 			tooltipwidget = {
+	# 				using = colonial_charter_migration_tooltip
+	# 			}
+	# 		}
+	# 	}
+	# }
+
+	# type pop_type_buildings = widget {
+	# 	size = {60 30}
+
+	# 	card_header_button_04 = {
+	# 		size = { 100% 100% }
+	# 		parentanchor = center
+	# 		datacontext = "[LocationView.GetLocation]"
+
+	# 		tooltipwidget = {
+	# 			using = BuildingInLocation_tooltip
+	# 			blockoverride "BuildingInLocation_title"{
+	# 				text = "BUILDINGS_IN_LOCATION_FROM_POPTYPE"
+	# 			}
+	# 			blockoverride "building_in_location_info" {
+	# 				textcontext = "[LocationView.GetPopTypeBuildingsInfo(PopType.GetKey)]"
+	# 			}
+	# 		}
+
+	# 		action_tooltip = {
+	# 			click_type = left
+	# 			click_mode = single
+	# 			on_action = "[OpenLateralViewWithFilter('production', PopType.GetKey)]"
+	# 			on_action = "[ShowLocationProductionView(LocationView.GetLocation.GetId, '(bool)no')]"
+	# 			title = "MANAGE_BUILDINGS_POP_TYPE"
+	# 		}
+
+	# 		background = {
+	# 			using = color_grey_texture
+	# 			modify_texture = {
+	# 				texture = "gfx/interface/cards/headers/header_pattern_01.dds"
+	# 				texture_density = 2
+	# 				spriteType = corneredtiled
+	# 				blend_mode = overlay
+	# 				alpha = 0.2
+	# 			}
+
+	# 			modify_texture = {
+	# 				texture = "gfx/interface/component_overlay/cloth_texture.dds"
+	# 				texture_density = 2
+	# 				spriteType = Corneredtiled
+	# 				spriteborder = { 0 0 }
+	# 				blend_mode = overlay
+	# 				alpha = 0.2
+	# 			}
+
+	# 			modify_texture = {
+	# 				color = "[PopType.GetColor]"
+	# 				blend_mode = overlay
+	# 				alpha = 0.7
+	# 			}
+	# 		}
+
+	# 		hbox = {
+	# 			margin = { 5 0 }
+	# 			icon = {
+	# 				size = { 25 25 }
+	# 				texture = "gfx/interface/buttons/flats/buildings_button.dds"
+	# 				modify_texture = {
+	# 					using = overlay_window_texture
+	# 					blend_mode = overlay
+	# 					alpha = 0.7
+	# 				}
+
+	# 				modify_texture = {
+	# 					using = color_new_gold_texture
+	# 				}
+
+	# 				modify_texture = {
+	# 					texture = "gfx/interface/buttons/buttons_texture.dds"
+	# 					texture_density = 2
+	# 					blend_mode = overlay
+	# 					alpha = 0.6
+	# 				}
+
+	# 				icon = {
+	# 					parentanchor = bottom|right
+	# 					texture = "[GetGraphicalCultureTextureForCountryPopType(PopType.Self, LocationView.GetLocation.GetOwner.Self)]"
+	# 					size = {50% 50% }
+	# 				}
+	# 			}
+
+	# 			text_single = {
+	# 				layoutpolicy_horizontal = expanding
+	# 				size = { -1 20 }
+	# 				autoresize = no
+	# 				text = "[LocationView.GetNumPopTypeBuildings(PopType.Self)]"
+	# 				align = center
+	# 			}
+	# 		}
+	# 	}
+	# }
+
+	# type pop_type_location_population = widget {
+	# 	size = {70 30}
+	# 	# block "pop_type_location_population_visible" {
+	# 		visible = "[And(LocationView.GetPopTypeItem(PopType.Self).HasPop,
+	# 		Not(And(GreaterThan_int32(LocationView.GetNumPopTypeWithBuildings, '(int32)7'), ObjectsEqual(GetPopTypeByName('slaves'), PopType.Self))))]"
+	# 	# }
+
+	# 	card_header_button_04 = {
+	# 		size = { 100% 100% }
+	# 		parentanchor = center
+	# 		datacontext = "[LocationView.GetLocation]"
+
+	# 		tooltipwidget = {
+	# 			using = locationview_employed_tt
+	# 		}
+
+	# 		action_tooltip = {
+	# 			click_type = left
+	# 			click_mode = single
+	# 			title = "OPEN_POP_TYPE_PEOPLE_VIEW"
+	# 			on_action = "[ShowCountryPeopleViewWithPopFilter(PopType.Self, '(bool)yes')]"
+	# 			on_action = "[ShowCountryPeopleViewWithLocation(LocationView.GetLocation.GetId, '(bool)no')]"
+	# 		}
+
+	# 		background = {
+	# 			using = color_grey_texture
+	# 			modify_texture = {
+	# 				texture = "gfx/interface/cards/headers/header_pattern_01.dds"
+	# 				texture_density = 2
+	# 				spriteType = corneredtiled
+	# 				blend_mode = overlay
+	# 				alpha = 0.2
+	# 			}
+
+	# 			modify_texture = {
+	# 				color = "[PopType.GetColor]"
+	# 				blend_mode = overlay
+	# 				alpha = 0.7
+	# 			}
+
+	# 			modify_texture = {
+	# 				texture = "gfx/interface/component_overlay/cloth_texture.dds"
+	# 				texture_density = 2
+	# 				spriteType = Corneredtiled
+	# 				spriteborder = { 0 0 }
+	# 				blend_mode = overlay
+	# 				alpha = 0.2
+	# 			}
+	# 		}
+
+	# 		vbox = {
+	# 			margin = { 7 0 }
+	# 			expand = {}
+	# 			hbox = {
+	# 				spacing = 2
+	# 				text_single = {
+	# 					maximumsize = { 34 20 }
+	# 					text = "[LocationView.GetLocation.GetTotalPopTypeSize(PopType.Self)]"
+	# 					align = center
+	# 				}
+
+	# 				icon = {
+	# 					size = { 12 12 }
+	# 					texture = "[GetGraphicalCultureTextureForCountryPopType(PopType.Self, LocationView.GetLocation.GetOwner.Self)]"
+	# 				}
+	# 			}
+	# 			progressbar = {
+	# 				visible = "[LocationView.GetPopTypeItem(PopType.Self).HasPop]"
+	# 				layoutpolicy_horizontal = expanding
+	# 				size = { -1 3 }
+	# 				using = progress_bar_blue_green_alt
+	# 				min = 0
+	# 				max = 1
+	# 				value = "[Subtract_float('(float)1.0', FixedPointToFloat(LocationView.GetLocation.GetUnEmployedPercentageWithConstruction(PopType.Self)))]"
+	# 				direction = horizontal
+	# 			}
+
+	# 			expand = {}
+	# 		}
+	# 	}
+	# }
+}
+
+template location_fort_status {
+	hbox = {
+		spacing = 2
+		icon = {
+			visible = "[Not(Location.HasFort)]"
+			size = { 21 21 }
+			alwaystransparent = yes
+			texture = "gfx/interface/icons/flat_icons/no_fort.dds"
+		}
+	
+		piechart = {
+			visible = "[Location.HasFort]"
+			size = { 21 21 }
+			alwaystransparent = yes
+	
+			pieslice_no_highlight = {
+				texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+				value = "[FixedPointToFloat(Location.GetGarrisonPercentage)]"
+				color = { 1 1 1 1 }
+				alwaystransparent = yes
+			}
+	
+			pieslice_no_highlight = {
+				texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+				value = "[Subtract_float('(float)1.0', FixedPointToFloat(Location.GetGarrisonPercentage))]"
+				color = { 1 1 1 1 }
+				alwaystransparent = yes
+			}
+	
+			icon = {
+				size = { 62% 62% }
+				parentanchor = center
+				texture = "[GetConceptTexture('fort')]"
+				texture_density = 2
+			}
+	
+			using = bg_circle_piechart
+		}
+	
+		text_single = {
+			visible = "[And(Location.HasSiege, GreaterThan_int32(Location.GetFortLevel, '(int32)0' ))]"
+			text = "[Location.GetRomanFortLevel]"
+			size = { 20 20 }
+			autoresize = no
+			align = center
+		}
+	}
+
+	text_single = {
+		margin_left = 5
+		visible = "[Not(Location.HasSiege)]"
+		text = "[SelectLocalization(GreaterThan_int32(Location.GetFortLevel, '(int32)0' ), 'FORT_LOCATION_LEVEL', 'NO_FORT_LOCATION_LEVEL')]"
+		layoutpolicy_horizontal = expanding
+		size = { -1 20 }
+		autoresize = no
+		align = left|nobaseline
+	}
+
+	expand = {}
+
+	# SIEGE OCCUPATION
+	hbox = {
+		visible = "[Location.HasSiege]"
+		spacing = 4
+
+		country_flag_small = {
+			visible = "[Location.GetSiege.GetBesieger.IsValid]"
+			size = { 36 24 }
+			datacontext = "[Location.GetSiege.GetBesieger]"
+		}
+
+		hbox = {
+			datacontext = "[Location.GetSiege]"
+			using = siege_fall_chance_info
+		}
+	}
+
+	block "location_fort_status_extra" {}
+}
+
+template siege_fall_chance_info {
+	hbox = {
+		spacing = 4
+		tooltipwidget = {
+			container = {
+				container = {
+					using = SiegePhase_tooltip
+					visible = "[Siege.IsSiege]"
+				}
+
+				container = {
+					using = Occupation_tooltip
+					visible = "[Not(Siege.IsSiege)]"
+				}
+			}
+		}
+
+		text_single = {
+			visible = "[And(Siege.IsSiege, Not(Siege.GetWar.IsPlayerInWar))]"
+			text = "[Siege.GetFallChance|2%]"
+			align = nobaseline
+			tooltipwidget = {
+				using = SiegeOutcome_tooltip
+			}
+		}
+		#GREEN
+		text_single = {
+			visible = "[And3(Siege.IsSiege, Siege.GetWar.IsPlayerInWar, Or(Siege.GetBesieger.IsPlayer, Siege.GetBesieger.IsAllied))]"
+			text = "[Siege.GetFallChance|2%G]"
+			align = nobaseline
+			tooltipwidget = {
+				using = SiegeOutcome_tooltip
+			}
+		}
+		#RED
+		text_single = {
+			visible = "[And3(Siege.IsSiege, Siege.GetWar.IsPlayerInWar, Not(Or(Siege.GetBesieger.IsPlayer, Siege.GetBesieger.IsAllied)))]"
+			text = "[Siege.GetFallChance|2%R]"
+			align = nobaseline
+			tooltipwidget = {
+				using = SiegeOutcome_tooltip
+			}
+		}
+
+		piechart = {
+			size = { 20 20 }
+			visible = "[Not(Siege.GetLocation.HasCombat)]"
+
+			using = bg_circle
+			using = piechart_angles
+			using = bg_circle_piechart
+
+			icon = {
+				size = { 70% 70% }
+				parentanchor = center
+				tooltipwidget = {
+					using = SiegeOutcome_tooltip
+				}
+				siege_icon = {
+					parentanchor = center
+				}
+
+				icon = {
+					size = {70% 70%}
+					parentanchor = center
+					visible = "[Or(Siege.IsTooFewMen, Siege.GetLocation.HasCombat)]"
+					texture = "gfx/interface/icons/flat_icons/disable_icon.dds"
+					using = color_red
+				}
+			}
+
+			pieslice_no_highlight = {
+				texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+				value = "[Siege.GetSiegePhaseProgress]"
+				color = { 0.01 0.6 0.9 1 }
+			}
+
+			pieslice_no_highlight = {
+				texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+				value = "[Subtract_float('(float)100.0', Siege.GetSiegePhaseProgress)]"
+				color = { 0.0 0.1 0.1 1 }
+			}
+		}
+
+		piechart = {
+			size = { 20 20 }
+			visible = "[Siege.GetLocation.HasCombat]"
+
+			using = bg_circle
+			using = piechart_angles
+			using = bg_circle_piechart
+
+			icon = {
+				size = { 70% 70% }
+				parentanchor = center
+				tooltipwidget = {
+					using = SiegeOutcome_tooltip
+				}
+				siege_icon = {
+					parentanchor = center
+				}
+
+				icon = {
+					size = {70% 70%}
+					parentanchor = center
+					visible = "[Or(Siege.IsTooFewMen, Siege.GetLocation.HasCombat)]"
+					texture = "gfx/interface/icons/flat_icons/disable_icon.dds"
+					using = color_red
+				}
+			}
+
+			pieslice_no_highlight = {
+				texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+				value = "[Siege.GetSiegePhaseProgress]"
+				color = { 0.5 0.5 0.5 1 }
+			}
+
+			pieslice_no_highlight = {
+				texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+				value = "[Subtract_float('(float)100.0', Siege.GetSiegePhaseProgress)]"
+				color = { 0.0 0.1 0.1 1 }
+			}
+		}
+	}
+}
+template location_side_color {
+	# PLAYER
+	modify_texture = {
+		visible = "[Location.GetController.IsPlayer]"
+		using = color_market_green_texture
+		texture_density = 2
+	}
+	# ALLIE
+	modify_texture = {
+		visible = "[Location.GetController.IsAllied]"
+		using = color_market_blue_texture
+		texture_density = 2
+	}
+	# ENEMY
+	modify_texture = {
+		visible = "[Player.IsEnemy(Location.GetController.Self)]"
+		using = color_market_red_texture
+		texture_density = 2
+	}
+	# NEUTRAL
+	modify_texture = {
+		visible = "[Location.GetController.IsNeutral]"
+		using = color_market_grey_texture
+		texture_density = 2
+	}
+
+	modify_texture = {
+		visible = "[Location.GetController.IsNeutral]"
+		using = color_white_texture
+		texture_density = 2
+		alpha = 0.1
+	}
+}
+
+template icon_gold_texture_alt {
+	modify_texture = {
+		using = overlay_window_texture
+		blend_mode = overlay
+		alpha = 0.4
+	}
+
+	modify_texture = {
+		using = color_new_gold_texture
+	}
+	modify_texture = {
+		using = color_black_texture
+		blend_mode = multiply
+		alpha = 0.1
+	}
+
+	modify_texture = {
+		texture = "gfx/interface/buttons/buttons_texture.dds"
+		texture_density = 2
+		blend_mode = overlay
+		alpha = 0
+	}
+}
+
+template card_button_alt_frame {
+	# texture = "gfx/interface/buttons/card_navigational_frame.dds"
+	# spriteType = corneredstretched
+	# spriteborder = { 19 19 }
+	# texture_density = 2
+	# frame_grid = {4 1}
+	using = header_button_texture
+
+	# modify_texture = {
+	# 	using = color_new_gold_texture
+	# 	blend_mode = add
+	# }
+	# modify_texture = {
+	# 	using = overlay_stone_texture
+	# 	blend_mode = overlay
+	# 	alpha = 0.3
+	# }
+	# modify_texture = {
+	# 	using = overlay_window_texture
+	# 	alpha = 0.1
+	# }
+}
+
+template location_background {
+	background = {
+		texture = "[GetGraphicalCultureTexture('top_header_bg')]"
+		texture_density = 2
+		spriteType = corneredtiled
+		spriteborder = { 0 0 }
+		alpha = 0.6
+	}
+	background = {
+		visible = "[Location.GetOwner.IsPlayer]"
+		using = color_society_texture
+		alpha = 0.8
+	}
+	background = {
+		visible = "[Location.GetOwner.IsAllied]"
+		using = color_diplomacy_texture
+		alpha = 0.8
+	}
+	background = {
+		visible = "[GetPlayer.IsEnemy(Location.GetOwner.Self)]"
+		using = color_military_texture
+		alpha = 0.8
+	}
+	background = {
+		visible = "[And4(
+			Not(Location.GetOwner.IsPlayer),
+			Not(GetPlayer.IsEnemy(Location.GetOwner.Self)),
+			Not(Location.GetOwner.IsAllied), 
+			IsInDiplomaticRange(Location.GetOwner.Self))]"
+		using = color_bg_brown_texture
+		alpha = 0.8
+	}
+	background = {
+		visible = "[Not(IsInDiplomaticRange(Location.GetOwner.Self))]"
+		using = color_grey_texture
+		alpha = 0.8
+		modify_texture = {
+			using = color_black_texture
+			alpha = 0.4
+			blend_mode = multiply
+		}
+	}
+}
+
+# template card_button_bg_alt
+# {
+# 	texture = "gfx/interface/buttons/card_navigational_bg.dds"
+# 	texture_density = 2
+# 	frame_grid = {4 1}
+# 	frame = 4
+# }
+
+lateralview = {
+	name = "location_window"
+	widgetid = "location_window"
+
+	widget = {
+		visible = "[TutorialIsRunning]"
+		widget = {
+			widgetid = "location_window_player_capital"
+			visible = "[ObjectsEqual(Player.GetCapital.Self, LocationView.GetLocation.Self)]"
+		}
+	}
+
+	blockoverride "lateralview_topbuttons_extra" {
+		widget = {
+			parentanchor = right|vcenter
+			size = { 40 40 }
+			position = { -30 0 }
+			
+			button = {
+				parentanchor = right|vcenter
+
+				size = { 25 25 }
+				texture = "gfx/interface/icons/unit_actions/go_to.dds"
+
+				modify_texture = {
+					using = color_white_texture
+					alpha = 0.1
+				}
+
+				action_tooltip = {
+					title = "GO_TO_LOCATION"
+					on_action = "[PanToLocation(LocationView.GetLocation)]"
+				}
+
+				tooltipwidget = { BasicFunctionalTooltip = {} }
+				using = snd_UI_backward
+			}
+		}
+	}
+
+	blockoverride "panel_header" {
+		window_header_alt = {
+			using = bg_main_inner_alt
+			blockoverride "window_header_alt_color_texture"{
+				using = color_default_brown_texture
+			}
+			
+			blockoverride "header_text_object" {
+				hbox = {
+					button = {
+						using = layoutpolicy_expanding
+						visible = "[Not(LocationView.Vars.Exists('edit_name'))]"
+
+						action_tooltip = {
+							click_type = right
+							click_mode = single
+
+							cursor = "location_menu"
+							title = "CLICK_ACTION_LOCATION_CONTEXT_MENU"
+							on_action = "[PdxGuiWidget.ToggleContextMenu]"
+						}
+
+						tagtooltip_enabled = yes
+						tooltip = "[LocationView.GetLocation.GetName]"
+						datacontext = "[LocationView.GetLocation]"
+						contextmenu_widget = {
+							LocationContextMenu = {
+								blockoverride "location_contextmenu_post_entries" {
+									ContextMenuEntry = {
+										datacontext = "[LocationView.GetRenameUIClickAction]"
+										visible = "[UIClickAction.IsVisible]"
+
+										blockoverride "onclick" {
+											onclick = "[LocationView.PerformRename]"
+											enabled = "[UIClickAction.IsEnabled]"
+											tooltip = "[UIClickAction.GetDescription]"
+										}
+
+										blockoverride "entry_icon_texture" {
+											texture = "gfx/interface/buttons/flats/buildings_button.dds"
+											# using = ui_direction_button_overlay
+										}
+
+										blockoverride "entry_text" {
+											text = "[UIClickAction.GetName]"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+
+				hbox = {
+					spacing = 5
+					expand = {}
+
+					widget = {
+						visible = "[And(Not(LocationView.Vars.Exists('edit_name')), LocationView.GetLocation.GetProvince.GetCountry.IsValid)]"
+						size = { 28 28 }
+						datacontext = "[LocationView.GetLocation]"
+						icon = {
+							parentanchor = center
+							size = { 90% 90% }
+							texture = "[Location.GetRankIcon]"
+						}
+
+						tooltipwidget = {
+							using = location_rank_tooltip
+						}
+					}
+
+					header_title = {
+						layoutpolicy_horizontal = fixed
+						autoresize = yes
+						maximumsize = { 380 -1 }
+						visible = "[Not(LocationView.Vars.Exists('edit_name'))]"
+						text = "[LocationView.GetLocation.GetRankAndName]"
+						using = snd_UI_window_state
+					}
+
+					button_pin = {
+						size = { 23 23 }
+						visible = "[And(IsPlayerValid, Not(LocationView.Vars.Exists('edit_name')))]"
+						datacontext = "[LocationView.GetLocation]"
+						onclick = "[ToggleLocationFav(Location.Self)]"
+						checked = "[IsLocationFaved(Location.Self)]"
+						tooltipwidget = {
+							LeftClickButtonTooltip = {
+								blockoverride "onclick_text" {
+									text = "[SelectLocalization(IsLocationFaved(Location.Self), 'UNPIN_OUTLINER', 'PIN_OUTLINER')]"
+								}
+							}
+						}
+					}
+
+					expand = {}
+				}
+
+				hbox = {
+					editbox = {
+						name = "location_name"
+						using = layoutpolicy_expanding
+						default_format = "#high"
+						using = Font_Size_Medium
+						align = center|nobaseline
+
+						text = "[LocationView.GetLocation.GetNameWithNoTooltip]"
+
+						oneditingfinished = "[LocationView.RenameLocation]"
+						oneditingfinished = "[LocationView.Vars.Clear('edit_name')]"
+
+						focus_on_visible = yes
+						focuspolicy = all
+						alwaystransparent = no
+
+						maxcharacters = 32
+
+						visible = "[LocationView.Vars.Exists('edit_name')]"
+						multiline = no
+					}
+				}
+			}
+		}
+	}
+
+	blockoverride "panel_content" {
+		vbox = {
+			using = layoutpolicy_expanding
+			using = bg_main_inner_notabs_alt
+			using = window_main_tabs_margin_alt
+
+			widget = {
+				layoutpolicy_horizontal = expanding
+				size = { -1 45 }
+
+				hbox = {
+					margin = { 10 0 }
+					datacontext = "[LocationView.GetLocation]"
+					hbox = {
+						layoutpolicy_horizontal = expanding
+						layoutstretchfactor_horizontal = 1
+						subheader_unified_icon = {
+							alwaystransparent = no
+							onmousehierarchyenter = "[PdxGuiWidget.SetHighlightProvince(Location.GetProvince)]"
+							visible = "[Location.HasOwner]"
+							datacontext = "[Location.GetProvince]"
+							margin = { 0 0 }
+							maximumsize = {165 -1}
+							layoutpolicy_horizontal = expanding
+							tooltipwidget = {
+								using = province_tooltip
+							}
+							blockoverride "subheader_unified_icon_texture" {
+								using = province_texture
+
+								glow = {
+									name = "drop_shadow"
+									glow_radius = 3
+									color = {0.0 0.0 0.0 1.0}
+									alpha = 0.6
+								}
+							}
+							blockoverride "subheader_unified_top_text" {
+								text = "game_concept_province"
+								align = nobaseline
+							}
+							blockoverride "subheader_unified_text_maxsize" { maximumsize = { 125 20 } }
+							blockoverride "subheader_unified_bottom_text" {
+								text = "[Province.GetNameWithNoTooltip]"
+								align = nobaseline
+							}
+							blockoverride "subheader_unified_icon_post"{
+								expand = {}
+							}
+						}
+
+						subheader_unified_icon = {
+							visible = "[Not(Location.HasOwner)]"
+							datacontext = "[Location.GetProvinceDefinition]"
+							margin = { 0 0 }
+							maximumsize = {165 -1}
+							layoutpolicy_horizontal = expanding
+							tooltipwidget = {
+								using = ProvinceDefinition_tooltip
+							}
+							blockoverride "subheader_unified_icon_texture" {
+								using = province_texture
+
+								glow = {
+									name = "drop_shadow"
+									glow_radius = 3
+									color = {0.0 0.0 0.0 1.0}
+									alpha = 0.6
+								}
+							}
+							blockoverride "subheader_unified_text_maxsize" { maximumsize = { 125 20 } }
+							blockoverride "subheader_unified_top_text" {
+								text = "game_concept_province"
+								align = nobaseline
+							}
+							blockoverride "subheader_unified_bottom_text" {
+								text = "[ProvinceDefinition.GetNameWithNoTooltip]"
+								align = nobaseline
+							}
+							blockoverride "subheader_unified_icon_post"{
+								expand = {}
+							}
+						}
+
+						expand = {}
+					}
+
+					# OWNER FLAG
+					widget = {
+						visible = "[Location.HasOwner]"
+						size = { 72 48 }
+
+						country_flag_mid = {
+							parentanchor = center
+							size = { 80% 80% }
+							datacontext = "[Location.GetOwner]"
+						}
+					}
+
+
+					hbox = {
+						datacontext = "[Location.GetProvince]"
+						layoutpolicy_horizontal = expanding
+						layoutstretchfactor_horizontal = 1
+						expand = {}
+						subheader_unified_icon = {
+							visible = "[Location.HasOwner]"
+							blockoverride "mirror_layout" {
+								righttoleft = yes
+							}
+							expand = {}
+							margin = { 0 0 }
+							maximumsize = {165 -1}
+							layoutpolicy_horizontal = expanding
+
+							tooltipwidget = {
+								using = province_food_tooltip
+							}
+
+							blockoverride "subheader_unified_icon_texture" {
+								piechart = {
+									size = { 30 30 }
+									using = bg_circle
+									using = bg_circle_piechart
+									using = piechart_angles
+
+									pieslice_no_highlight = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+										value = "[FixedPointToFloat(Province.GetFoodCapacityPercent)]"
+										color = { 1 1 1 1 }
+									}
+
+									pieslice_no_highlight = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+										value = "[Subtract_float('(float)100.0', FixedPointToFloat(Province.GetFoodCapacityPercent))]"
+										color = { 1 1 1 1 }
+									}
+
+									icon = {
+										size = {  71% 71% }
+										texture = "gfx/interface/icons/unit_view/food.dds"
+										parentanchor = vcenter|hcenter
+
+										modify_texture = {
+											visible = "[Province.IsRiskOfStarving]"
+											using = color_black_texture
+											alpha = 0.5
+											blend_mode = multiply
+										}
+
+										modify_texture = {
+											visible = "[Province.IsRiskOfStarving]"
+											using = color_yellow_texture
+											alpha = 0.6
+										}
+
+										modify_texture = {
+											visible = "[Province.IsStarving]"
+											using = color_black_texture
+											alpha = 0.5
+											blend_mode = multiply
+										}
+
+										modify_texture = {
+											visible = "[Province.IsStarving]"
+											using = color_mid_red_texture
+										}
+									}
+								}
+							}
+							blockoverride "subheader_unified_text_maxsize" { maximumsize = { 125 20 } }
+							blockoverride "subheader_unified_top_text" {
+								text = "game_concept_provincial_food"
+								align = right|nobaseline
+							}
+
+							blockoverride "unified_icon_bottom_content" {
+								spacing = 5
+
+								text_single = { ### PROVINCE FOOD (GREEN IF POSITIVE)
+									visible = "[GreaterThanOrEqualTo_CFixedPoint(Province.GetMonthlyFood, '(CFixedPoint)0')]"
+									raw_text = "[Province.GetMonthlyFood|2+=]"
+									align = right|nobaseline
+									minimumsize = { -1 20 }
+									maximumsize = { 45 20 }
+									fontsize = 13
+								}
+
+								hbox = {
+									visible = "[Not(GreaterThanOrEqualTo_CFixedPoint(Province.GetMonthlyFood, '(CFixedPoint)0'))]"
+									text_single = { ### PROVINCE FOOD (WHITE IF LOCAL PRODUCTION IS NEGATIVE, BUT BUYING ENOUGH FROM MARKET)
+										# raw_text = "[Add_float(FixedPointToFloat(Province.GetFoodFromMarket), FixedPointToFloat(Province.GetMonthlyFood))|+=2]"
+										visible = "[GreaterThanOrEqualTo_float(
+											Add_float(
+												FixedPointToFloat(Province.GetFoodFromMarket), 
+												FixedPointToFloat(Province.GetMonthlyFood)
+											), 
+											'(float)0'
+										)]"
+										raw_text = "[Province.GetMonthlyFood|2H]"
+										align = right|nobaseline
+										minimumsize = { -1 20 }
+										maximumsize = { 45 20 }
+										fontsize = 13
+									}
+									text_single = { ### PROVINCE FOOD (RED IF STOCKPILE IS DECREASING)
+										visible = "[LessThan_float(
+											Add_float(
+												FixedPointToFloat(Province.GetFoodFromMarket), 
+												FixedPointToFloat(Province.GetMonthlyFood)
+											), 
+											'(float)0'
+										)]"
+										raw_text = "[Province.GetMonthlyFood|2R]"
+										align = right|nobaseline
+										minimumsize = { -1 20 }
+										maximumsize = { 45 20 }
+										fontsize = 13
+									}
+								}
+
+							}
+						}
+					}
+				}
+			}
+
+			# LOCATION CARD
+			vbox = {
+				layoutpolicy_horizontal = expanding
+				margin_bottom = 5
+				name = "location_main_content"
+				datacontext = "[LocationView.GetLocation]"
+
+				# LOCATION FILTERED
+				widget = {
+					layoutpolicy_horizontal = expanding
+					size = { -1 73 }
+
+					hbox = {
+						using = bg_market_card
+						using = bg_cabinet_card_frame
+
+						location_card = {
+							blockoverride "location_card_margins" {
+								margin = {0 5}
+								margin_left = 5
+							}
+						}
+
+						location_card_right_buttons = {
+							blockoverride "location_filter_middle_button" {
+								vbox = {
+									layoutpolicy_vertical = expanding
+									spacing = 3
+
+									filter_button_alt = {
+										size = { 19 19 }
+										blockoverride "filter_button_action" {
+											action_tooltip = {
+												click_type = left
+												click_mode = single
+												title = "TOGGLE_LOCATION_SELECTION"
+												on_action = "[LocationView.ToggleLocationViewSelectProvince(PdxGuiWidget.FindParent('location_main_content').Self)]"
+											}
+										}
+										tooltipwidget = { BasicFunctionalTooltip = {} }
+
+										blockoverride "glow_visible" {
+											visible = "[LocationView.IsLocationViewSelectProvinceOpened(PdxGuiWidget.FindParent('location_main_content').Self)]"
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			# SCENE
+			widget = {
+				layoutpolicy_horizontal = expanding
+				size = { -1 220 }
+
+				using = bg_age_event_frame
+
+				hbox = {
+					ecs_scene_viewer_widget =  {
+						layoutpolicy_horizontal = expanding
+						layoutpolicy_vertical = expanding
+						name = "event_window_scene_viewer"
+						scene = "[LocationView.GenerateSceneDesc]"
+					}
+				}
+
+				widget = {
+					parentanchor = center
+					size = { 100% 40 }
+					datacontext = "[LocationView.GetLocation]"
+					visible = "[Location.IsOccupied]"
+					tooltipwidget = {										
+						ContextualTooltipType = {
+							blockoverride "title_text" {								
+								text = "game_concept_occupied"
+							}
+							
+							blockoverride "title_icon" {
+								country_flag_small = {
+									size = { 36 24 }
+									datacontext = "[Location.GetController]"
+								}
+							}
+
+							blockoverride "concept_link" {
+								text = "[occupied|e]"
+							}
+
+							blockoverride "tooltip_content" {
+								TooltipTextBlock = {
+									visible = "[Location.IsOccupied]"
+									blockoverride "text" {
+										text = "LOCATION_TOOLTIP_OCCUPIED"
+										using = Font_Size_Medium
+									}
+								}
+							}
+						}
+					}	
+					background = {
+						texture = "gfx/interface/colors/black.dds"
+						alpha = 1
+						modify_texture = {
+							texture = "gfx/interface/component_masks/mask_fade_horizontal_middle.dds"
+							blend_mode = alphamultiply
+						}
+					}
+					background = {
+						texture = "gfx/interface/colors/red.dds"
+						alpha = 0.5
+						modify_texture = {
+							texture = "gfx/interface/component_masks/mask_fade_horizontal_middle.dds"
+							blend_mode = alphamultiply
+						}
+					}
+
+					hbox = {
+						hbox = {
+							spacing = 4
+							# TRANSFER OCCUPATION
+							button_regular = {
+								size = { 40 40}
+								visible = "[And4(Location.IsOccupied, Not(Location.HasSiege), Not(IsLateralViewOpened('select_interaction_target')), Or(Location.GetController.IsPlayer, Location.GetController.GetDiplomacy.IsSubjectOf(GetPlayer)))]"
+
+								using = location_background
+
+								tooltipwidget = {
+									SimpleContextualTooltipType = {
+										blockoverride "title_icon" {
+											icon = {
+												using = tooltip_title_icon_size
+												texture = "gfx/interface/icons/flat_icons/declare_war/transfer_occupation.dds"
+											}
+										}
+										lowpriotextcontext = "[Location.GetTransferOccupationTooltip]"
+									}
+								}
+
+								enabled = "[Location.CanTransferOccupation]"
+								action_tooltip = {
+									click_type = left
+									click_mode = single
+									title = "TRANFER_OCC_TITLE_ACTION"
+									enabled = "[Location.CanTransferOccupation]"
+									on_action = "[ShowTransferOccupation(Location.Self)]"
+								}
+
+								action_tooltip = {
+									click_type = right
+									click_mode = single
+									title = "TRANFER_OCC_PROVINCE_TITLE_ACTION"
+									enabled = "[Location.CanTransferOccupation]"
+									on_action = "[ShowTransferProvinceOccupation(Location.Self)]"
+								}
+
+								icon = {
+									size = { 30 30 }
+									parentanchor = center
+									texture = "gfx/interface/icons/flat_icons/declare_war/transfer_occupation.dds"
+									glow = {
+										name = "drop_shadow"
+										glow_radius = 3
+										color = {0.0 0.0 0.0 1.0}
+										alpha = 0.3
+									}
+								}	
+							}
+
+							text_single = {
+								align = nobaseline
+								maximumsize = { 450 -1 }
+								text = "LOCATION_TOOLTIP_OCCUPIED"
+								#text = "game_concept_occupied"
+								using = Font_Type_Headers
+								using = Font_Size_Medium
+							}
+						}		
+					}
+				}
+			
+				vbox = {
+					expand = {}
+					
+					# IOs & PERIPHORA
+					widget = {
+						layoutpolicy_horizontal = expanding
+						size = {-1 48}
+						hbox = {
+							spacing = 2
+							# IO
+							hbox = {
+								# SHOW IO
+								hbox = {
+									spacing = 3
+									visible = "[Not(LocationView.GetLocation.GetOwner.IsPlayer)]"
+									datamodel = "[LocationView.GetPlayer.GetInternationalOrganizations]"
+									item = {
+										header_button_left = {
+											size = {40 40}
+											blockoverride "button_icon_stretch_sprite" {}
+											blockoverride "header_button_frame_inner" {visible = no}
+											blockoverride "header_button_icon_size" { size = { 40 40 } }
+											blockoverride "header_button_text_layout" {}
+
+											blockoverride "icon_texture" {
+												texture = "[InternationalOrganization.GetIcon]"
+												texture_density = 2
+											}
+											visible = "[And(InternationalOrganization.CanOwnLocations, InternationalOrganization.IsLocationOwned(LocationView.GetLocation))]"
+											onclick = "[OpenInternationalOrganizationView(InternationalOrganization.Self)]"
+											tooltipwidget = {
+												LeftClickButtonTooltip = {
+													blockoverride "onclick_text" {
+														text = "OPEN_IO"
+													}
+												}
+											}
+										}
+									}
+								}
+
+								# ADD TO IO
+								hbox = {
+									spacing = 3
+									visible = "[LocationView.GetLocation.GetOwner.IsPlayer]"
+									datamodel = "[LocationView.GetPlayer.GetInternationalOrganizations]"
+									item = {
+										header_action_button_left = {
+											size = {40 40}
+											blockoverride "button_icon_stretch_sprite" {}
+											blockoverride "header_button_frame_inner" {visible = no}
+											blockoverride "header_button_icon_size" { size = { 40 40 } }
+											blockoverride "header_button_text_layout" {}
+
+											blockoverride "icon_texture" {
+												texture = "[InternationalOrganization.GetIcon]"
+												texture_density = 2
+											}
+											visible = "[And3(UIAction.IsVisible, InternationalOrganization.CanOwnLocations, Not(InternationalOrganization.IsLocationOwned(LocationView.GetLocation)))]"
+											
+											title = "add_location_to_international_organization"
+											actor = "[LocationView.GetPlayer]"
+											parameter = {
+												parameter_name = "target"
+												parameter_value = "[LocationView.GetLocation]"
+											}
+											parameter = {
+												parameter_name = "target_1"
+												parameter_value = "[InternationalOrganization.MakeScope]"
+											}
+											left_click_and_hold_action = { action_name = "add_location_to_international_organization" }
+											tooltipwidget = {
+												ContextualTooltipType = {
+													blockoverride "title_icon_texture" {
+														texture = "[InternationalOrganization.GetIcon]"
+													}
+												
+													blockoverride "title_text" {
+														text = "ADD_TO_IO_TOOLTIP_T"
+													}
+													blockoverride "concept_link" {
+														text = "[international_organization|e]"
+													}
+													
+													blockoverride "tooltip_content" {
+														TooltipTextBlock = {
+															visible = "[Not(StringIsEmpty(UIAction.GetEffects))]"
+															blockoverride "text" { text = "[UIAction.GetEffects]" }
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+								
+								# REMOVE FROM IO
+								hbox = {
+									spacing = 3
+									visible = "[LocationView.GetLocation.GetOwner.IsPlayer]"
+									datamodel = "[LocationView.GetLocation.GetInternationalOrganizations]"
+									item = {
+										header_action_button_left = {
+											size = {40 40}
+											blockoverride "button_icon_stretch_sprite" {}
+											blockoverride "header_button_frame_inner" {visible = no}
+											blockoverride "header_button_icon_size" { size = { 40 40 } }
+											blockoverride "header_button_text_layout" {}
+											blockoverride "icon_overlay" {}
+
+											blockoverride "icon_texture" {
+												texture = "[InternationalOrganization.GetIcon]"
+												texture_density = 2
+											}
+											visible = "[And3(UIAction.IsVisible, InternationalOrganization.CanOwnLocations, InternationalOrganization.IsLocationOwned(LocationView.GetLocation))]"
+											
+											title = "remove_location_from_international_organization"
+											actor = "[GetPlayer]"
+											parameter = {
+												parameter_name = "target"
+												parameter_value = "[LocationView.GetLocation]"
+											}
+											parameter = {
+												parameter_name = "target_1"
+												parameter_value = "[InternationalOrganization.MakeScope]"
+											}
+											right_click_and_hold_action = { action_name = "remove_location_from_international_organization" }
+											tooltipwidget = {
+												ContextualTooltipType = {
+													blockoverride "title_icon_texture" {
+														texture = "[InternationalOrganization.GetIcon]"
+													}
+												
+													blockoverride "title_text" {
+														text = "REMOVE_FROM_IO_TOOLTIP_T"
+													}
+													blockoverride "concept_link" {
+														text = "[international_organization|e]"
+													}
+													
+													blockoverride "tooltip_content" {
+														TooltipTextBlock = {
+															visible = "[Not(StringIsEmpty(UIAction.GetEffects))]"
+															blockoverride "text" { text = "[UIAction.GetEffects]" }
+														}
+
+														TooltipTextBlock = {
+															visible = "[InternationalOrganization.GetOnRemovedLocation(LocationView.GetLocation)]"										
+															blockoverride "text" { text = "[InternationalOrganization.GetOnRemovedLocation(LocationView.GetLocation)]" }
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+
+							# PERIPHORA
+							header_action_button_left = {
+								size = {40 40}
+								blockoverride "button_icon_stretch_sprite" {}
+								blockoverride "header_button_frame_inner" {visible = no}
+								blockoverride "header_button_icon_size" { size = { 40 40 } }
+								blockoverride "header_button_text_layout" {}
+
+								blockoverride "icon_texture" {
+									texture = "gfx/interface/buttons/flats/periphora.dds"
+									texture_density = 2
+								}
+
+								name = "periphora"
+								actor = "[LocationView.GetPlayer]"
+								parameter = {
+									parameter_name = "location"
+									parameter_value = "[LocationView.GetLocation]"
+								}
+								left_action = { action_name = "periphora" }
+
+								tooltipwidget = {
+									ContextualTooltipType = {
+										blockoverride "title_icon" {
+											icon = {
+												using = tooltip_title_icon_size
+												texture = "gfx/interface/buttons/flats/periphora.dds"
+											}
+										}
+
+										blockoverride "title_text" {
+											text = "periphora"
+										}
+										blockoverride "tooltip_content" {
+											TooltipTextBlock = {
+												blockoverride "text" {
+													text = "periphora_desc"
+												}
+											}
+										}
+									}
+								}
+							}
+
+							expand = {}
+						}
+					}
+					# BOTTOM CONDITIONS
+					hbox = {
+						layoutpolicy_horizontal = expanding
+						maximumsize = { -1 40 }
+						background = {
+							using = color_dark_blue_texture
+							alpha = 1
+
+							modify_texture = {
+								using = bg_fade_vertical_up_mask_texture
+								blend_mode = alphamultiply
+								alpha = 1
+							}
+						}
+						hbox = {
+							margin = {10 8}
+
+							using = bg_paper_card
+							using = bg_cabinet_card_frame
+
+							hbox = {
+								spacing = 5
+
+								widget = {
+									size = { 30 30 }
+									datacontext = "[LocationView.GetLocation.GetTopography]"
+									tooltipwidget = {
+										using = Topography_tooltip
+									}
+									background =  {
+										texture = "[GetClimateFrame(LocationView.GetLocation.GetClimate)]"
+									}
+									icon = {
+										size = { 30 30 }
+										texture = "[GetTopographyIcon(LocationView.GetLocation.GetTopography)]"
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+								}
+
+								widget = {
+									size = { 30 30 }
+									datacontext = "[LocationView.GetLocation.GetClimate]"
+									tooltipwidget = {
+										using = Climate_tooltip
+									}
+									background =  {
+										texture = "[GetClimateFrame(LocationView.GetLocation.GetClimate)]"
+									}
+									icon = {
+										size = { 30 30 }
+										texture = "[GetClimateIcon(LocationView.GetLocation.GetClimate)]"
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+								}
+
+								widget = {
+									size = { 30 30 }
+									datacontext = "[LocationView.GetLocation.GetVegetation]"
+									tooltipwidget = {
+										using = Vegetation_tooltip
+									}
+									background =  {
+										texture = "[GetClimateFrame(LocationView.GetLocation.GetClimate)]"
+									}
+									icon = {
+										size = { 30 30 }
+										texture = "[GetVegetationIcon(LocationView.GetLocation.GetVegetation)]"
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+								}
+
+								### NOT COASTAL
+								widget = {
+									size = { 30 30 }
+									visible = "[Not(LocationView.GetLocation.IsCoastal)]"
+									datacontext = "[LocationView.GetLocation]"
+
+									tooltipwidget = {
+										using = Inland_tooltip
+									}
+
+									background =  {
+										texture = "[GetClimateFrame(LocationView.GetLocation.GetClimate)]"
+									}
+									icon = {
+										size = { 30 30 }
+										texture = "gfx/interface/icons/location_icons/inland.dds"
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+								}
+
+								### COASTAL
+								widget = {
+									size = { 30 30 }
+									visible = "[LocationView.GetLocation.IsCoastal]"
+
+									tooltipwidget = {
+
+										ContextualTooltipType = {
+											blockoverride "title_text" {
+												datacontext = "[LocationView.GetLocation]"
+
+												text = "COASTAL_LOCATION"
+											}
+
+											blockoverride "title_icon" {
+												ContextualTooltipDefaultIcon = {
+													visible = "[Not(LocationView.GetLocation.IsBlockadedByEnemies)]"
+													blockoverride "title_icon_texture" {
+														texture = "gfx/interface/icons/location_icons/coastal.dds"
+													}
+												}
+
+												ContextualTooltipDefaultIcon = {
+													visible = "[LocationView.GetLocation.IsBlockadedByEnemies]"
+													blockoverride "title_icon_texture" {
+														texture = "gfx/interface/icons/location_icons/coastal_blockade.dds"
+													}
+												}
+											}
+
+											blockoverride "title_button" {
+												mapmode_tooltip_button = {
+													datacontext = "[GetMapMode('maritime')]"
+												}
+											}
+
+											blockoverride "concept_link" {
+												text = [coastal|e]
+											}
+
+											blockoverride "tooltip_content" {
+												datacontext = "[LocationView.GetLocation]"
+												TooltipStringPairList = {
+													visible = "[LocationView.GetLocation.IsBlockadedByEnemies]"
+													blockoverride "block_title" {
+														text = "BLOCKADED_BY_ENEMIES"
+													}
+													textcontext = "[LocationView.GetLocation.GetBlockadeImpact]"
+												}
+												TooltipStringPairList = {
+													textcontext = "[ShowModifierEffect('coastal')]"
+												}
+												TooltipStringPairList = {
+													blockoverride "block_title" {
+														datacontext = "[LocationView.GetLocation]"
+														text = "BLOCKADE_FORCE_REQUIRED_TT"
+													}
+													textcontext = "[LocationView.GetLocation.GetDescriptionFor('blockade_force_required')]"
+												}
+
+												TooltipTextBlock = {
+													blockoverride "text" {
+														text = "LOC_COASTAL_SEAZONE_PORT"
+													}
+												}
+											}
+										}
+									}
+
+									background =  {
+										texture = "[GetClimateFrame(LocationView.GetLocation.GetClimate)]"
+									}
+									icon = {
+										size = { 100% 100% }
+										texture = "gfx/interface/icons/location_icons/coastal.dds"
+										visible = "[Not(LocationView.GetLocation.IsBlockadedByEnemies)]"
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+
+									icon = {
+										size = { 100% 100% }
+										texture = "gfx/interface/icons/location_icons/coastal_blockade.dds"
+										visible = "[LocationView.GetLocation.IsBlockadedByEnemies]"
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+								}
+
+								### IS BLOCKADED by ice
+								widget = {
+									size = { 30 30 }
+									visible = "[LocationView.GetLocation.IsBlockadedByIce]"
+									tooltipwidget = {
+
+										ContextualTooltipType = {
+											blockoverride "title_text" {
+												datacontext = "[LocationView.GetLocation]"
+												text = "BLOCKADED_BY_ICE"
+											}
+
+											blockoverride "title_icon_texture" {
+												texture = "gfx/interface/icons/location_icons/coastal_blockade.dds"
+											}
+
+											blockoverride "concept_link" {
+												text = [blockade|E]
+											}
+
+											blockoverride "tooltip_content" {
+												TooltipStringPairList = {
+													textcontext = "[LocationView.GetLocation.GetBlockadeImpact]"
+												}
+											}
+										}
+									}
+									background =  {
+										texture = "[GetClimateFrame(LocationView.GetLocation.GetClimate)]"
+									}
+									icon = {
+										size = { 30 30 }
+										texture = "gfx/interface/icons/location_icons/blockade_byice.dds"
+										using = overlay_color_light_blue
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+								}
+							}
+						}
+
+						widget = {
+							using = layoutpolicy_expanding
+
+							hbox = {
+								margin = { 5 5 }
+								spacing = 7
+								# NATURAL HABOUR
+								widget = {
+									visible = "[LocationView.GetLocation.IsCoastal]"
+									size = {28 28}
+
+									datacontext = "[LocationView.GetLocation]"
+									tooltipwidget = {
+										using = HarborCapacity_tooltip
+									}
+
+									piechart = {
+										using = bg_circle
+										size = { 100% 100% }
+										using = piechart_angles
+										using = bg_circle_piechart
+
+										icon = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+											size = { 97% 97% }
+											parentanchor = center
+											color = { 0 0 0 1 }
+										}
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+											value = "[FixedPointToFloat(LocationView.GetLocation.GetModifierValueFixed('harbor_suitability'))]"
+											color = { 0.3 0.8 0.3 1 }
+											alpha = 0.8
+										}
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+											value = "[Max_float(Subtract_float('(float)1.0', FixedPointToFloat(LocationView.GetLocation.GetModifierValueFixed('harbor_suitability'))), '(float)0')]"
+											color = { 0.8 0.3 0.3 1 }
+											alpha = 0.8
+										}
+
+										icon = {
+											size = { 19 19 }
+											parentanchor = center
+											texture = "[GetConceptTexture('harbor_capacity')]"
+										}
+									}
+								}
+
+								# RIVER MODIFIER
+								icon = {
+									size = { 28 28 }
+									visible = "[LocationView.GetLocation.HasRiver]"
+									texture = "[GetConceptTexture('river')]"
+									datacontext = "[LocationView.GetLocation]"
+
+									tooltipwidget = {
+										using = RiverModifier_tooltip
+									}
+								}
+
+								# SOUND TOLL
+								icon = {
+									size = { 30 30 }
+									visible = "[LocationView.GetLocation.IsSoundTollLand]"
+									texture = "[GetConceptTexture('sound_toll')]"
+									datacontext = "[LocationView.GetLocation.GetSoundTollController]"
+
+									tooltipwidget = {
+										using = SoundTollLocationTooltip
+									}
+								}
+
+								# VOLCANO
+								icon = {
+									size = { 30 30 }
+									visible = "[LocationView.GetLocation.HasVolcano]"
+									texture = "gfx/interface/topography/volcano.dds"
+
+									tooltipwidget = {
+										SimpleContextualTooltipType = {
+											blockoverride "title_icon" {
+												icon = {
+													using = tooltip_title_icon_size
+													texture = "gfx/interface/topography/volcano.dds"
+												}
+											}
+											lowpriotextcontext =  "VOLCANO_LOCATION_TOOLTIP"
+										}
+									}
+								}
+
+								# WINTER
+								icon = {
+									size = { 30 30 }
+									visible = "[LocationView.GetLocation.HasWinter]"
+									datacontext = "[LocationView.GetLocation]"
+									texture = "[GetWinterIcon(LocationView.GetLocation)]"
+
+									tooltipwidget = {
+										using = location_winter_tooltip
+									}
+								}
+
+								# EARTQUAKE
+								icon = {
+									size = { 30 30 }
+									visible = "[LocationView.GetLocation.HasEarthquakes]"
+									texture = "gfx/interface/topography/earthquake.dds"
+									tooltipwidget = {
+										SimpleContextualTooltipType = {
+											blockoverride "title_icon" {
+												icon = {
+													using = tooltip_title_icon_size
+													texture = "gfx/interface/topography/earthquake.dds"
+												}
+											}
+											lowpriotextcontext =  "EARTHQUAKE_LOCATION_TOOLTIP"
+										}
+									}
+								}
+
+								# RAISED LEVIES MODIFIERS
+								icon = {
+									size = { 30 30 }
+									visible = "[LocationView.GetLocation.HasRaisedLevies]"
+									texture = "[GetConceptTexture('army_levies')]"
+									glow = {
+										name = "drop_shadow"
+										glow_radius = 3
+										color = {0.0 0.0 0.0 1.0}
+										alpha = 0.3
+									}
+									tooltipwidget = {
+										SimpleContextualTooltipType = {
+											blockoverride "title_text" {
+												text = "STATIC_MODIFIER_NAME_raised_levies"
+											}
+											blockoverride "title_icon" {
+												icon = {
+													using = tooltip_title_icon_size
+													texture = "[GetConceptTexture('army_levies')]"
+												}
+											}
+											lowpriotextcontext =  "[LocationView.GetLocation.GetLeviesInfo]"
+										}
+									}
+								}
+
+								# HOLY SITES
+								icon = {
+									size = { 30 30 }
+									texture = "gfx/interface/icons/location_icons/holy_sites.dds"
+									visible = "[Not(IsDataModelEmpty(LocationView.GetLocation.GetHolySites))]"
+									datacontext = "[LocationView.GetLocation]"
+
+									tooltipwidget = {
+										SimpleContextualRowTooltipType = {
+											blockoverride "title_icon" {
+												icon = {
+													using = tooltip_title_icon_size
+													texture = "gfx/interface/icons/location_icons/holy_sites.dds"
+												}
+											}
+											blockoverride "concept_link" {
+												text = "[holy_sites|e]"
+											}
+
+											lowpriotextcontext = "[LocationView.GetLocation.GetHolySitesTooltip]"
+										}
+									}
+
+									glow = {
+										name = "drop_shadow"
+										glow_radius = 3
+										color = {0.0 0.0 0.0 1.0}
+										alpha = 0.3
+									}
+								}
+
+								# ATTRITION
+								piechart = {
+									size = {28 28}
+									using = piechart_angles
+									datacontext = "[LocationView.GetLocation]"
+									visible = "[GreaterThan_CFixedPoint(Location.GetAppliedAttritionPercentage, '(CFixedPoint)0')]"
+									tooltipwidget = {
+										SimpleContextualStringPairTooltipType = {
+											blockoverride "title_icon" {
+												icon = {
+													using = tooltip_title_icon_size
+													texture = "gfx/interface/icons/location_icons/attrition.dds"
+												}
+											}
+											blockoverride "concept_link" {
+												text = "[attrition|e]"
+											}
+											lowpriotextcontext =  "[Location.GetAttritionDescription]"
+										}
+									}
+
+									icon = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+										size = { 97% 97% }
+										parentanchor = center
+										color = { 0 0 0 1 }
+									}
+
+									pieslice = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+										value = "[FixedPointToFloat(Location.GetAppliedAttritionPercentage)]"
+										color = { 0.8 0.3 0.3 1 }
+										alpha = 0.8
+									}
+
+									pieslice = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+										value = "[Subtract_float('(float)1.0', FixedPointToFloat(Location.GetAppliedAttritionPercentage))]"
+										using = color_value_progress_gray
+									}
+
+									icon = {
+										size = { 61% 61% }
+										parentanchor = center
+										texture = "gfx/interface/icons/location_icons/attrition.dds"
+									}
+								}
+
+								# DISEASES
+								piechart = {
+									datacontext = "[LocationView.GetLocation]"
+									visible = "[LocationView.ShowDisease]"
+									using = bg_circle
+									size = {28 28}
+									using = piechart_angles
+									using = bg_circle_piechart
+									tooltipwidget = {
+										using = location_disease_tooltip
+									}
+
+									icon = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+										size = { 97% 97% }
+										parentanchor = center
+										color = { 0 0 0 1 }
+									}
+
+									pieslice_no_highlight = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+										value = "[FixedPointToFloat(LocationView.GetDiseasePercentage)]"
+										color = { 0.3 0.8 0.3 1 }
+										alpha = 0.8
+									}
+
+									pieslice_no_highlight = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+										value = "[Subtract_float('(float)1.0', FixedPointToFloat(LocationView.GetDiseasePercentage))]"
+										color = { 0.8 0.3 0.3 1 }
+										alpha = 0.8
+									}
+
+									icon = {
+										size = { 61% 61% }
+										parentanchor = center
+										texture = "[GetDiseaseIcon(LocationView.GetHigherPresenceDisease)]"
+									}
+								}
+
+								# SPECIFIC BASE MODIFIER
+								icon = {
+									size = { 30 30 }
+									texture = "[LocationView.GetLocation.GetSpecificBaseModifier.GetModifier.GetIcon]"
+									visible = "[LocationView.GetLocation.HasSpecificBaseModifier]"
+									datacontext = "[LocationView.GetLocation]"
+									tooltipwidget = {
+										using = raw_good_location_modifier_tooltip
+									}
+								}
+
+								# Location timed modifiers
+								widget = {
+									size = { 45 26 }
+									visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetLocation.GetTimedModifiers), '(int32)0')]"
+
+									# RIGHT DIVISION
+									flowcontainer = {
+										visible = "[Not(GreaterThan_int32(GetDataModelSize(LocationView.GetLocation.GetTimedModifiers), '(int32)1'))]"
+
+										layoutpolicy_horizontal = expanding
+
+										datamodel = "[LocationView.GetLocation.GetTimedModifiers]"
+										item = {
+											timed_modifier_icon = {
+												datacontext = "[TimedModifier]"
+												tooltipwidget = {
+													using = timed_modifier_tooltip
+													blockoverride "concept_link" {
+														text = "[location_modifier|e]"
+													}
+												}
+											}
+										}
+
+										expand = {}
+									}
+
+									flowcontainer = {
+										visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetLocation.GetTimedModifiers), '(int32)1')]"
+
+										text_single = {
+											minimumsize = { -1 26 }
+											align = nobaseline|hcenter
+											text = "[GetDataModelSize(LocationView.GetLocation.GetTimedModifiers)]"
+										}
+										icon = {
+											size = { 26 26 }
+											texture = "gfx/interface/icons/modifiers/locations.dds"
+											texture_density = 2
+
+											tooltipwidget = {
+												ContextualTooltipType = {
+													blockoverride "title_icon" {
+														icon = {
+															texture = "gfx/interface/icons/modifiers/locations.dds"
+															using = tooltip_title_icon_size
+														}
+													}
+													blockoverride "title_text" {
+															text = "game_concept_location_modifier"
+													}
+													blockoverride "concept_link" {
+														text = [location_modifier|e]
+													}
+
+													blockoverride "tooltip_content" {
+														TooltipScrolledRowList = {
+															blockoverride "block_title" { visible = no }
+															blockoverride "rowlist_datamodel_is_empty" { visible = "[IsDataModelEmpty(LocationView.GetLocation.GetTimedModifiers)]"}
+															blockoverride "rowlist_datamodel_has_items" { visible = "[DataModelHasItems(LocationView.GetLocation.GetTimedModifiers)]"}
+															blockoverride "rowlist_datamodel" { datamodel = "[LocationView.GetLocation.GetTimedModifiers]" }
+															blockoverride "rowlist_content" {
+																hbox = {
+																	layoutpolicy_horizontal = expanding
+																	spacing = 10
+																	datacontext = "[TimedModifier]"
+																	tooltipwidget = {
+																		using = timed_modifier_tooltip
+																	}
+																	text_single = {
+																		margin_left = 20
+																		text = "[TimedModifier.GetModifier.GetName]"
+																	}
+																	timed_modifier_icon = {
+																		datacontext = "[TimedModifier]"
+																		tooltipwidget = {
+																			using = timed_modifier_tooltip
+																			blockoverride "concept_link" {
+																				text = "[location_modifier|e]"
+																			}
+																		}
+																	}
+
+																	expand = {}
+																}
+															}
+
+															blockoverride "block_scrollarea" {
+																maximumsize = { -1 210 }
+															}
+
+															blockoverride "row_size" {
+																maximumsize = { -1 40 }
+																minimumsize = { -1 40 }
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+
+								# Province timed modifiers
+								widget = {
+									size = { 45 26 }
+									visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetLocation.GetProvince.GetTimedModifiers), '(int32)0')]"
+
+									# RIGHT DIVISION
+									flowcontainer = {
+										visible = "[Not(GreaterThan_int32(GetDataModelSize(LocationView.GetLocation.GetProvince.GetTimedModifiers), '(int32)1'))]"
+
+										layoutpolicy_horizontal = expanding
+
+										datamodel = "[LocationView.GetLocation.GetProvince.GetTimedModifiers]"
+										item = {
+											timed_modifier_icon = {
+												datacontext = "[TimedModifier]"
+												tooltipwidget = {
+													using = timed_modifier_tooltip
+													blockoverride "concept_link" {
+														text = "[province_modifier|e]"
+													}
+												}
+											}
+										}
+
+										expand = {}
+									}
+
+									flowcontainer = {
+										visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetLocation.GetProvince.GetTimedModifiers), '(int32)1')]"
+
+										text_single = {
+											minimumsize = { -1 26 }
+											align = nobaseline|hcenter
+											text = "[GetDataModelSize(LocationView.GetLocation.GetProvince.GetTimedModifiers)]"
+										}
+										icon = {
+											size = { 26 26 }
+											texture = "gfx/interface/icons/modifiers/province.dds"
+											texture_density = 2
+
+											tooltipwidget = {
+												ContextualTooltipType = {
+													blockoverride "title_icon" {
+														icon = {
+															texture = "gfx/interface/icons/modifiers/province.dds"
+															using = tooltip_title_icon_size
+														}
+													}
+													blockoverride "title_text" {
+															text = "game_concept_location_modifier"
+													}
+													blockoverride "concept_link" {
+														text = [province_modifier|e]
+													}
+
+													blockoverride "tooltip_content" {
+														TooltipScrolledRowList = {
+															blockoverride "block_title" { visible = no }
+															blockoverride "rowlist_datamodel_is_empty" { visible = "[IsDataModelEmpty(LocationView.GetLocation.GetProvince.GetTimedModifiers)]"}
+															blockoverride "rowlist_datamodel_has_items" { visible = "[DataModelHasItems(LocationView.GetLocation.GetProvince.GetTimedModifiers)]"}
+															blockoverride "rowlist_datamodel" { datamodel = "[LocationView.GetLocation.GetProvince.GetTimedModifiers]" }
+															blockoverride "rowlist_content" {
+																hbox = {
+																	layoutpolicy_horizontal = expanding
+																	spacing = 10
+																	datacontext = "[TimedModifier]"
+																	tooltipwidget = {
+																		using = timed_modifier_tooltip
+																	}
+																	text_single = {
+																		margin_left = 20
+																		text = "[TimedModifier.GetModifier.GetName]"
+																	}
+																	timed_modifier_icon = {
+																		datacontext = "[TimedModifier]"
+																		tooltipwidget = {
+																			using = timed_modifier_tooltip
+																			blockoverride "concept_link" {
+																				text = "[province_modifier|e]"
+																			}
+																		}
+																	}
+
+																	expand = {}
+																}
+															}
+
+															blockoverride "block_scrollarea" {
+																maximumsize = { -1 210 }
+															}
+
+															blockoverride "row_size" {
+																maximumsize = { -1 40 }
+																minimumsize = { -1 40 }
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+
+								expand = {}
+							}
+						}
+
+						expand = {}
+					}
+				}
+			}
+
+			# TABS
+			header_secondary_tabs = {
+				blockoverride "content" {
+					button_secondary_tab_alt = {
+						using = layoutpolicy_expanding
+						blockoverride "tab_text"{
+							text = "LOC_VIEW_INFRASTRUCTURE_TAB"
+						}
+						tooltipwidget = { using = TabInfrastructureTooltip }
+						onclick = "[LocationView.Vars.Set( 'tab', 'infrastructure' )]"
+						down = "[LocationView.Vars.NotExistOrHasValue( 'tab', 'infrastructure' )]"
+					}
+
+					button_secondary_tab_alt = {
+						using = layoutpolicy_expanding
+						blockoverride "tab_text"{
+							text = "LOC_VIEW_MILITARY_TAB"
+						}
+						tooltipwidget = { using = SubTabMilitaryTooltip }
+						onclick = "[LocationView.Vars.Set( 'tab', 'military' )]"
+						down = "[LocationView.Vars.HasValue( 'tab', 'military' )]"
+					}
+
+					button_secondary_tab_alt = {
+						using = layoutpolicy_expanding
+						blockoverride "tab_text"{
+							text = "LOC_VIEW_DEMOGRAPHICS_TAB"
+						}
+						tooltipwidget = { using = TabDemographicsTooltip }
+						onclick = "[LocationView.Vars.Set( 'tab', 'demography' )]"
+						down = "[LocationView.Vars.HasValue( 'tab', 'demography' )]"
+					}
+				}
+			}
+
+			vbox = {
+				using = layoutpolicy_expanding
+				using = bg_secondary_inner_image_alt
+				blockoverride "image" {
+					texture = "gfx/interface/illustrations/bg/bg_foreign_country.dds"
+				}
+				datacontext = "[LocationView.GetLocation]"
+
+				# INFRASTRUCTURE
+				vbox = {
+					visible = "[LocationView.Vars.NotExistOrHasValue( 'tab', 'infrastructure' )]"
+					layoutpolicy_horizontal = expanding
+					layoutpolicy_vertical = expanding
+
+					vbox = {
+						using = layoutpolicy_expanding
+						margin = { 5 10 }
+						margin_top = 5
+
+						scroll_list = {
+							using = layoutpolicy_expanding
+							blockoverride "scroll_list_layout" {
+								vbox = {
+									using = layoutpolicy_expanding
+									spacing = 6
+
+									# INFRASTRUCTURE HUB
+									hbox = {
+										visible = "[LocationView.GetLocation.HasRawMaterial]"
+										using = layoutpolicy_expanding
+										maximumsize = { -1 46 }
+
+										# ROAD BUILDER
+										header_button_right = {
+											name = "location_road"
+											size = { 125 40}
+											datacontext = "[LocationView.GetLocation]"
+											tooltipwidget = { 
+													blockoverride "shift_left_extra" {
+														replacement_shift_item = {}
+													}
+												BasicFunctionalTooltip = {} 
+											}
+
+											onmousehierarchyenter = "[LocationView.OnMouseEnterBuildRoadButton]"
+											onmousehierarchyleave = "[LocationView.OnMouseLeaveBuildRoadButton]"
+
+											action_tooltip = {
+												click_type = left
+												click_mode = single
+												title = "LOC_OPEN_ROADS"
+												on_action = "[ShowRoadbuilder(LocationView.GetLocation)]"
+											}
+
+											action_tooltip = {
+												visible = "[Not(And(Location.IsCapital, Location.GetOwner.IsPlayer))]"
+												click_type = right
+												click_mode = confirm
+												conditions = "LOC_CANNOT_BUILD_ROAD_TO_CAPITAL"
+												title = "LOC_BUILD_ROAD_TO_CAPITAL"
+												enabled = [LocationView.IsBuildRoadToCapitalEnabled]
+												on_action = "[LocationView.BuildRoadToCapital]"
+											}
+
+											action_tooltip = {
+												click_modifier = shift
+												click_type = left
+												title = "OPEN_HINT"
+												on_action = "[OpenLateralViewWithParams('hints', 'selected_hint = hint_control')]"
+											}
+
+											blockoverride "bg_color" {
+												modify_texture = {
+													using = color_dark_brown_texture
+													blend_mode = multiply
+												}
+											}
+
+											blockoverride "header_button_icon_obj" {
+												icon = { ## ROAD ICON
+													parentanchor = center
+													size = { 30 30 }
+													texture = "gfx/interface/buttons/flats/roads.dds"
+													using = icon_gold_texture_alt
+												}
+											}
+
+											blockoverride "header_button_text_layout" {
+												hbox = {
+													using = layoutpolicy_expanding
+													margin = { 5 2}
+													#margin_left = 2
+													spacing = 10
+
+													vbox = {
+														using = layoutpolicy_expanding
+
+														hbox = {
+															layoutpolicy_horizontal = expanding
+															layoutpolicy_vertical = expanding
+															spacing = 5
+
+															expand = {}
+
+															text_single = {
+																align = right|nobaseline
+																layoutpolicy_horizontal = expanding
+																size = { -1 17 }
+																autoresize = no
+																raw_text = "game_concept_roads"
+																default_format = "#explanation_link"
+
+															}
+														}
+
+														hbox = {
+															using = layoutpolicy_expanding
+															spacing = 5
+															margin_left = 10
+
+															text_single = {
+																align = right|nobaseline
+																minimumsize = { 65 17 }
+																maximumsize = { 65 17 }
+																autoresize = yes
+																text = "LOC_VIEW_ROADS"
+																default_format = "#flavor"
+															}
+														}
+													}
+												}
+											}
+										}
+
+										hbox = {
+											using = layoutpolicy_expanding
+											widget = {
+												size = {270 51}
+												datacontext = "[LocationView.GetLocation]"
+
+												# CONTROL
+												widget = {
+													size = { 61 46 }
+													parentanchor = center|vcenter
+													piechart = {
+														parentanchor = center|vcenter
+														name = "location_control"
+														using = bg_circle
+														size = { 46 46 }
+														datacontext = "[LocationView.GetLocation]"
+														tooltipwidget = {
+															using = location_control_tooltip
+															blockoverride "location_control_widgetid" {
+																widgetid = "location_control_tooltip_id"
+															}
+														}
+														using = piechart_angles
+
+														pieslice_no_highlight = {
+															texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+															value = "[FixedPointToFloat(Location.GetControl)]"
+															color = { 1 1 1 1 }
+															alwaystransparent = yes
+														}
+
+														pieslice_no_highlight = {
+															texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+															value = "[Subtract_float('(float)1.0', FixedPointToFloat(Location.GetControl))]"
+															color = { 1 1 1 1 }
+															alwaystransparent = yes
+														}
+
+														icon = {
+															size = { 60% 60% }
+															parentanchor = center
+															texture = "gfx/interface/icons/location_icons/control.dds"
+														}
+
+														using = bg_circle_piechart
+													}
+													using = bg_control_romboid
+												}
+
+												# PROXIMITY
+												widget = {
+													name = "location_proximity"
+													size = { 100 40 }
+													parentanchor = left|vcenter
+
+													datacontext = "[LocationView.GetLocation]"
+													tooltipwidget = {
+														using = LocationProximity_tooltip
+														blockoverride "location_proximity_widgetid" {
+															widgetid = "location_proximity_tooltip_id"
+														}
+													}
+
+													hbox = {
+														margin_right = 22
+														hbox = {
+															using = layoutpolicy_expanding
+															margin = { 6 0 }
+															margin_right = 23
+
+															using = bg_paper_card
+															using = bg_cabinet_card_frame
+
+															text_single = {
+																visible = "[Not(Location.IsCapital)]"
+																align = right|nobaseline
+																layoutpolicy_horizontal = expanding
+																size = { -1 15 }
+																autoresize = no
+																fontsize = 14
+																raw_text = "[Location.GetProximityToOwnerCapital|0]%"
+															}
+
+															text_single = {
+																visible = "[Location.IsCapital]"
+																align = right|nobaseline
+																layoutpolicy_horizontal = expanding
+																size = { -1 15 }
+																autoresize = no
+																fontsize = 14
+																raw_text = "100%"
+															}
+														}
+													}
+
+													widget = {
+														size = {40 40}
+														parentanchor = right|vcenter
+														# PROXIMITY CHART
+														piechart = {
+															parentanchor = center
+															using = bg_circle
+															visible = "[Not(Location.IsCapital)]"
+															size = { 37 37 }
+															using = piechart_angles
+
+															pieslice_no_highlight = {
+																texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+																value = "[FixedPointToFloat(LocationView.GetLocation.GetProximityToOwnerCapital)]"
+																color = { 1 1 1 1 }
+															}
+
+															pieslice_no_highlight = {
+																texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+																value = "[Subtract_float('(float)100.0', FixedPointToFloat(LocationView.GetLocation.GetProximityToOwnerCapital))]"
+																color = { 1 1 1 1 }
+															}
+
+															using = bg_circle_piechart
+
+															icon = {
+																size = { 59% 59% }
+																parentanchor = center
+																texture = "gfx/interface/icons/location_icons/distance_capital.dds"
+															}
+														}
+
+														piechart = {
+															parentanchor = center
+															using = bg_circle
+															visible = "[Location.IsCapital]"
+															size = { 36 36 }
+															datacontext = "[LocationView.GetLocation]"
+															tooltipwidget = {
+																using = LocationProximity_tooltip
+																blockoverride "location_proximity_widgetid" {
+																	widgetid = "location_proximity_tooltip_id2"
+																}
+															}
+															using = piechart_angles
+
+															pieslice_no_highlight = {
+																texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+																value = 100.0
+																color = { 1 1 1 1 }
+															}
+
+															using = bg_circle_piechart
+
+															icon = {
+																size = { 59% 59% }
+																parentanchor = center
+																texture = "gfx/interface/icons/location_icons/distance_capital.dds"
+															}
+														}
+													}
+												}
+												
+												# TAX BASE
+												widget = {
+													name = "location_tax_base"
+													size = { 100 40 }
+													parentanchor = right|vcenter
+
+													tooltipwidget = {
+														using = location_tax_base_tooltip
+													}
+
+													hbox = {
+														margin_left = 22
+														hbox = {
+															using = layoutpolicy_expanding
+															margin = { 6 0 }
+															margin_left = 23
+
+															using = bg_paper_card
+															using = bg_cabinet_card_frame
+
+
+															vbox = {
+																layoutpolicy_horizontal = expanding
+																spacing = -2
+																text_single = {
+																	align = left|nobaseline
+																	layoutpolicy_horizontal = expanding
+																	size = { -1 21 }
+																	autoresize = no
+																	fontsize = 15
+																	raw_text = "[Location.GetTotalPossibleTaxBase|W2]"
+																}
+																text_single = {
+																	align = left|nobaseline
+																	layoutpolicy_horizontal = expanding
+																	size = { -1 13 }
+																	autoresize = no
+																	fontsize = 12
+																	raw_text = "[Location.GetTotalIncome|g2]@income!"
+																	default_format = "#bold"
+																}
+															}
+														}
+													}
+
+													widget = {
+														size = {40 40}
+														parentanchor = left|vcenter
+
+														widget = {
+															size = {37 37}
+															parentanchor = right|vcenter
+															using = bg_circle_piechart
+	
+															# TAX BASE CHART
+															# icon_pie_left = {
+															# 	parentanchor = center
+															# 	blockoverride "PieSize_bckg" {}
+															# 	blockoverride "PieSize" { size = { 39 39 } }
+															# 	blockoverride "pie_datamodel" {
+															# 		datacontext = "[Location.GetPopulationChart]"
+															# 		datacontext = "[LocationPopulationChart.GetPopsPiechartWidget]"
+															# 		datamodel = "[PopsPiechartWidget.GetTax]"
+															# 	}
+	
+															# 	###Slices and Icon
+															# 	blockoverride "SliceTooltip" {}
+															# 	blockoverride "SliceValue" { value = "[PopTaxItem.GetPercentage]" }
+															# 	blockoverride "SliceColor" { color = "[PopTaxItem.GetColor]" }
+															# 	blockoverride "Icon" { texture = "gfx/interface/icons/location_icons/tax_base.dds" }
+															# 	blockoverride "Icon_Size" { size = { 65% 65% } }
+															# 	blockoverride "datamodel" { visible = no }
+															# }
+															icon_pie_left = {
+																parentanchor = center
+																blockoverride "PieSize_bckg" {}
+																blockoverride "PieSize" { size = { 39 39 } }
+																blockoverride "pie_datamodel" { datamodel = "[DataModelSkipFirst(Location.GetOwner.GetGovernment.GetEstates, '(int32)1')]" }
+
+																blockoverride "pieslice_item" {
+																	pieslice_no_highlight = {
+																		texture = "gfx/interface/pie_charts/piechart_alpha.dds"
+																		texture_density = 2
+																		tooltip_enabled = no
+																		value = "[Location.GetEstateTaxBasePercent(Estate.Self)]"
+																		color = "[Estate.GetType.GetMapColor]"
+																		alpha = 0.99
+																		alwaystransparent = yes
+																	}
+																}
+																blockoverride "Icon" { texture = "[GetConceptTexture('wealth')]" }
+																blockoverride "Icon_Size" { size = { 65% 65% } }
+															}
+														}
+													}
+												}
+											}
+										}
+
+										# RGO
+										header_button_left = {
+											name = "location_rgo"
+											size = { 125 40}
+											enabled = "[Location.GetOwner.IsPlayer]"
+
+											datacontext = "[LocationView.GetLocation]"
+											tooltipwidget = {
+												using = location_rgo_button_tooltip
+											}
+
+										action_tooltip = {
+											click_type = left
+											click_mode = single
+
+											title = "MANAGE_LOCATION_BUILDINGS"
+											on_action = "[GetScriptedGui('mnt_set_rgo_buildings_visible_on').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
+											on_action = "[OpenLateralViewWithParams('location_production', 'display = lists')]"
+											on_action = "[OpenLateralViewWithFilter('location_production', LocationView.GetLocation.GetRawMaterial.GetKey)]"
+											on_action = "[ShowLocationProductionView(LocationView.GetLocation.GetId, '(bool)no')]"
+										}
+
+											blockoverride "bg_color" {
+												modify_texture = {
+													using = color_dark_brown_texture
+													blend_mode = multiply
+												}
+											}
+
+											blockoverride "header_button_icon_obj" {
+												piechart = {
+													visible = "[GreaterThan_CFixedPoint(Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level'), '(CFixedPoint)0')]"
+													alwaystransparent = yes
+													parentanchor = center
+													size = { 30 30 }
+													using = piechart_angles
+													using = bg_circle_piechart
+													pieslice_no_highlight = {
+														filter_mouse = none
+														alwaystransparent = yes
+														texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+														value = "[Divide_CFixedPoint(Location.MakeScope.ScriptValue('mnt_location_current_rgo_building_level'), Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level'))]"
+														color = { 1 1 1 1 }
+													}
+
+													pieslice_no_highlight = {
+														filter_mouse = none
+														alwaystransparent = yes
+														texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+														value = "[Subtract_float('(float)1.0', FixedPointToFloatPercentageCapped(Divide_CFixedPoint(Location.MakeScope.ScriptValue('mnt_location_current_rgo_building_level'), Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level')), '(bool)yes'))]"
+														color = { 1 1 1 1 }
+													}
+												}
+
+												button = {
+													size = { 100% 100% }
+													parentanchor = center
+
+												action_tooltip = {
+													click_type = left
+													click_mode = single
+													title = "MANAGE_LOCATION_BUILDINGS"
+													on_action = "[GetScriptedGui('mnt_set_rgo_buildings_visible_on').Execute(GuiScope.SetRoot(Player.MakeScope).End)]"
+													on_action = "[OpenLateralViewWithParams('location_production', 'display = lists')]"
+													on_action = "[OpenLateralViewWithFilter('location_production', LocationView.GetLocation.GetRawMaterial.GetKey)]"
+													on_action = "[ShowLocationProductionView(LocationView.GetLocation.GetId, '(bool)no')]"
+												}
+
+													datacontext = "[LocationView.GetLocation.GetRawMaterial]"
+													datacontext = "[LocationView.GetLocation.GetOwner]"
+													datacontext = "[LocationView.GetLocation.GetMarket]"
+													tooltipwidget = {
+														using = SpecificGoodsMarket_tooltip
+													}
+
+													icon = {
+														alwaystransparent = yes
+														size = { 18 18 }
+														parentanchor = center
+														texture = "[GetGoodsIcon(LocationView.GetLocation.GetRawMaterial)]"
+													}
+												}
+											}
+
+											blockoverride "header_button_text_layout" {
+												hbox = {
+													using = layoutpolicy_expanding
+													margin_left = 5
+													margin_right = 2
+
+													vbox = {
+														layoutpolicy_horizontal = expanding
+														layoutpolicy_vertical = expanding
+
+														hbox = {
+															layoutpolicy_horizontal = expanding
+															layoutpolicy_vertical = expanding
+															spacing = 5
+
+															text_single = {
+																maximumsize = { 70 -1 }
+																align = left|nobaseline
+																autoresize = yes
+																fontsize = 13
+																text = "[LocationView.GetLocation.GetRawMaterial.GetNameWithNoTooltip|L]"
+															}
+
+															expand = {}
+														}
+
+														hbox = {
+															layoutpolicy_horizontal = expanding
+															#layoutpolicy_vertical = expanding
+															margin_bottom = 2
+															datacontext = "[LocationView.GetLocation]"
+
+															text_single = {
+																align = left|nobaseline
+																maximumsize = { 70 -1 }
+																fontsize = 14
+																datacontext = "[Location.GetRawMaterial]"
+																raw_text = "[Location.MakeScope.ScriptValue('mnt_location_current_rgo_building_level')|0]/[Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level')|0]"
+															}
+
+															text_single = {
+																visible = no
+																align = left|nobaseline
+																maximumsize = { 70 -1 }
+																fontsize = 14
+																datacontext = "[Location.GetRawMaterial]"
+																raw_text = "[Location.MakeScope.ScriptValue('mnt_location_current_rgo_building_level')|0]/[Location.MakeScope.ScriptValue('mnt_location_max_rgo_building_level')|0]"
+															}
+
+															expand = {}
+														}
+													}
+												}
+											}
+										}
+									}
+
+									# DEVELOPMENT PROPSERITY WoA INSTITUTIONS FOOD
+									widget = {
+										layoutpolicy_horizontal = expanding
+										size = { -1 35 }
+										hbox = {
+											# DEVELOPMENT
+											widget = {
+												size = { 80 35 }
+												sneaky_button = {
+													size = { 100% 100% }
+													action_tooltip = {
+														click_type = left
+														click_mode = single
+														title = "develop_province"
+														on_action = "[ShowSelectCabinetToDevelopProvince(Location.GetProvince)]"
+														enabled = "[And(IsCabinetActionAllowed('develop_province'), Location.GetOwner.IsPlayer)]"
+														conditions = "[GetCabinetActionTooltip('develop_province')]"
+													}
+													enabled = "[And(IsCabinetActionAllowed('develop_province'), Location.GetOwner.IsPlayer)]"
+
+													tooltipwidget = {
+														using = location_development_tooltip
+													}
+												}
+												hbox = {
+													spacing = 7
+													margin_left = 5
+
+													widget = {
+														size = { 25 25 }
+
+														piechart = {
+															parentanchor = center
+															size = { 100% 100% }
+															alwaystransparent = yes
+															using = piechart_angles
+
+															pieslice_no_highlight = {
+																texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+																value = "[FixedPointToFloat(Location.GetDevelopment)]"
+																color = { 1 1 1 1 }
+																alwaystransparent = yes
+															}
+
+															pieslice_no_highlight = {
+																texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+																value = "[Subtract_float('(float)100.0', FixedPointToFloat(Location.GetDevelopment))]"
+																color = { 1 1 1 0.2 }
+																alwaystransparent = yes
+															}
+
+															icon = {
+																size = { 60% 60% }
+																parentanchor = center
+																texture = "gfx/interface/icons/location_icons/development.dds"
+															}
+
+															using = bg_circle_piechart
+														}
+													}
+
+													text_single = {
+														layoutpolicy_horizontal = expanding
+														size = { -1 16 }
+														autoresize = no
+														raw_text = "[Location.GetDevelopment|2]"
+														align = left|nobaseline
+													}
+												}
+											}
+
+											# PROSPERITY
+											widget = {
+												size = { 80 35 }
+												sneaky_button = {
+													size = { 100% 100% }
+													action_tooltip = {
+														click_type = left
+														click_mode = single
+														title = "recovery_effort"
+														on_action = "[ShowSelectCabinetToRecoverEffort(Location.GetProvince)]"
+														enabled = "[And(IsCabinetActionAllowed('develop_province'), Location.GetOwner.IsPlayer)]"
+														conditions = "[GetCabinetActionTooltip('recovery_effort')]"
+													}
+													enabled = "[And(IsCabinetActionAllowed('recovery_effort'), Location.GetOwner.IsPlayer)]"
+
+													tooltipwidget = {
+														using = location_prosperity_tooltip
+													}
+												}
+												hbox = {
+													spacing = 7
+													margin_left = 5
+													widget = {
+														size = { 25 25 }
+
+														using = bg_circle_piechart
+
+														icon = {
+															visible = "[Not(LessThan_CFixedPoint(Location.GetProsperity, '(CFixedPoint)0.0'))]"
+															size = { 80% 80% }
+															parentanchor = center
+																texture = "gfx/interface/icons/location_icons/new/prosperity.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.3
+															}
+														}
+
+														icon = {
+															visible = "[LessThan_CFixedPoint(Location.GetProsperity, '(CFixedPoint)0.0')]"
+															size = { 80% 80% }
+															parentanchor = center
+																texture = "gfx/interface/icons/location_icons/prosperity_low.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.3
+															}
+														}
+													}
+
+													text_single = {
+														layoutpolicy_horizontal = expanding
+														size = { -1 16 }
+														autoresize = no
+														raw_text = "[Location.GetProsperity|2%+]"
+														align = left|nobaseline
+													}
+												}
+											}
+
+											# WoA
+											widget = {
+												size = { 80 35 }
+												sneaky_button = {
+													size = { 100% 100% }
+													action_tooltip = {
+														click_type = left
+														click_mode = single
+														title = "OPEN_WORKS_OF_ART_TAB"
+														on_action = "[OpenLateralViewWithParams('country_culture', 'subtab = works_of_art')]"
+													}
+
+													tooltipwidget = {
+														using = location_art_tooltip
+													}
+												}
+												hbox = {
+													spacing = 7
+													margin_left = 5
+													widget = {
+														size = { 25 25 }
+
+														using = bg_circle_piechart
+
+														icon = {
+															size = { 80% 80% }
+															parentanchor = center
+															texture = "gfx/interface/icons/flat_icons/art_works.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.3
+															}
+														}
+													}
+
+													text_single = {
+														layoutpolicy_horizontal = expanding
+														size = { -1 16 }
+														autoresize = no
+														text = "[Location.GetNumWorksOfArt]"
+														align = left|nobaseline
+													}
+												}
+											}
+											
+											hbox = {
+												margin = {3 0}
+												piechart = {
+													using = bg_circle
+													visible = "[Not(Location.HasTooManyBuildingLevel)]"
+													size = { 30 30 }
+													datacontext = "[LocationView.GetLocation]"
+													tooltipwidget = {
+														using = LocationBuildingLevels_tooltip
+													}
+													using = piechart_angles
+	
+													pieslice_no_highlight = {
+														
+														texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+														value = "[LocationView.GetLocation.GetBuildingLevelsPercentage]"
+														color = { 1 1 1 1 }
+													}
+	
+													pieslice_no_highlight = {
+														texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+														value = "[Subtract_float('(float)100.0', LocationView.GetLocation.GetBuildingLevelsPercentage)]"
+														color = { 1 1 1 1 }
+													}
+													using = bg_circle_piechart
+	
+													icon = {
+														size = { 59% 59% }
+														parentanchor = center
+														texture = "[GetConceptTexture('supported_building_levels')]"
+													}
+												}
+												
+												piechart = {
+													visible = "[Location.HasTooManyBuildingLevel]"
+													using = bg_circle
+													size = { 36 36 }
+													datacontext = "[LocationView.GetLocation]"
+													tooltipwidget = {
+														using = LocationBuildingLevels_tooltip
+													}
+													using = piechart_angles
+	
+							
+													pieslice_no_highlight = {
+														
+														texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+														value = 100
+														color = { 1 1 1 1 }
+													}
+													using = bg_circle_piechart
+	
+													icon = {
+														size = { 59% 59% }
+														parentanchor = center
+														texture = "[GetConceptTexture('supported_building_levels')]"
+													}
+												}
+											}
+
+
+											# INSTITUTION
+											widget = {
+												size = { 80 35 }
+												sneaky_button = {
+													size = { 100% 100% }
+													action_tooltip = {
+														click_type = left
+														click_mode = single
+														title = "OPEN_ADVANCES_AGES_TAB"
+														on_action = "[OpenLateralViewWithParams('advances', 'subtab = ages')]"
+													}
+
+													tooltipwidget = {
+														using = institution_in_location_tooltip
+													}
+												}
+												hbox = {
+													spacing = 7
+													margin_left = 5
+													
+													widget = {
+														size = { 25 25 }
+														
+														using = bg_circle_piechart
+	
+														icon = {
+															size = { 80% 80% }
+															parentanchor = center
+															texture = "gfx/interface/icons/location_icons/institutions.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.3
+															}
+														}
+													}
+
+													text_single = {
+														layoutpolicy_horizontal = expanding
+														size = { -1 16 }
+														autoresize = no
+														raw_text = "[Location.GetNumofInstitutionsEmbraced] / [Location.GetNumofInstitutionsKnown]"
+														align = left|nobaseline
+													}
+												}
+											}
+
+											# FOOD PRODUCTIVITY
+											widget = {
+												size = { 80 35 }
+												sneaky_button = {
+													size = { 100% 100% }
+													datacontext = "[Location.GetProvince]"
+
+													action_tooltip = {
+														click_type = left
+														click_mode = single
+														title = "BUILD_FOOD_BUILDINGS_LOCATION"
+														on_action = "[OpenLateralViewWithFilter('production', 'food_production')]"
+														on_action = "[ShowLocationProductionView(Location.GetId, '(bool)no')]"
+														enabled = "[Location.GetOwner.IsPlayer]"
+													}
+													action_tooltip = {
+														click_modifier = shift
+														click_type = left
+														title = "ALERT_HINT"
+														using = snd_UI_alert_openAndCycle
+														on_action = "[OpenLateralViewWithParams('hints', 'selected_hint = hint_food')]"
+														on_action = "[PdxGuiTriggerAllAnimations('reset_carousel')]"
+													}
+													enabled = "[Location.GetOwner.IsPlayer]"
+
+													tooltipwidget = {
+														using = food_productivity_tooltip
+														blockoverride "shift_left_extra" {
+															replacement_shift_item = {}
+														}
+													}
+												}
+												hbox = {
+													spacing = 7
+													margin_left = 5
+													widget = {
+														size = { 25 25 }
+
+														using = bg_circle_piechart
+
+														icon = {
+															size = { 80% 80% }
+															parentanchor = center
+															texture = "gfx/interface/icons/map_modes/food_productivity.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.3
+															}
+														}
+													}
+
+													text_single = {
+														layoutpolicy_horizontal = expanding
+														size = { -1 16 }
+														autoresize = no
+														raw_text = "[Location.GetFoodsOutputModifiers|+=0%]"
+														align = left|nobaseline
+													}
+												}
+											}
+
+											# LOCATION FOOD
+											widget = {
+												size = { 80 35 }
+												sneaky_button = {
+													size = { 100% 100% }
+													datacontext = "[Location.GetProvince]"
+
+													action_tooltip = {
+														click_type = left
+														click_mode = single
+														title = "SHOW_PROVINCE_FOOD"
+														on_action = "[ShowFoodProductionViewWithProvince(Location.GetProvince, '(bool)yes')]"
+														enabled = "[Location.GetOwner.IsPlayer]"
+													}
+													action_tooltip = {
+														click_modifier = shift
+														click_type = left
+														title = "ALERT_HINT"
+														using = snd_UI_alert_openAndCycle
+														on_action = "[OpenLateralViewWithParams('hints', 'selected_hint = hint_food')]"
+														on_action = "[PdxGuiTriggerAllAnimations('reset_carousel')]"
+													}
+													enabled = "[Location.GetOwner.IsPlayer]"
+
+													tooltipwidget = {
+														using = location_food_tooltip
+														blockoverride "shift_left_extra" {
+															replacement_shift_item = {}
+														}
+													}
+												}
+												hbox = {
+													spacing = 7
+													margin_left = 5
+													widget = {
+														size = { 25 25 }
+
+														using = bg_circle_piechart
+
+														icon = {
+															size = { 80% 80% }
+															parentanchor = center
+															texture = "gfx/interface/icons/unit_view/food.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.3
+															}
+														}
+													}
+
+													text_single = {
+														layoutpolicy_horizontal = expanding
+														size = { -1 16 }
+														autoresize = no
+														raw_text = "[Location.GetFoodsOutput|+=0]"
+														align = left|nobaseline
+													}
+												}
+											}
+										}
+									}
+
+									# COLONIAL CHARTERS
+									vbox = {
+										visible = "[Or(LocationView.ShowColonialCharterListWidget, LocationView.ShowCurrentColonyWidget)]"
+										layoutpolicy_horizontal = expanding
+										spacing = 5
+										margin_right = 2
+
+										vbox = {
+											layoutpolicy_horizontal = expanding
+											using = bg_paper_card
+											# Header
+											widget = {
+												layoutpolicy_horizontal = expanding
+												size = { -1 50 }
+												using = bg_card_header_01
+												using = bg_cabinet_card_frame
+
+												hbox = {
+													spacing = 4
+													margin = { 8 5 }
+
+													icon = {
+														size = { 30 30 }
+														texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+														texture_density = 2
+														alpha = 1
+													}
+
+													vbox = {
+														layoutpolicy_horizontal = expanding
+														text_single = {
+															layoutpolicy_horizontal = expanding
+															align = left
+															text = "[colonial_charter|e]"
+														}
+														text_single = {
+															layoutpolicy_horizontal = expanding
+															align = left
+															text = "[LocationView.GetNumColonialCharters]"
+														}
+													}
+
+													vbox = {
+														datacontext = "[LocationView.GetColonialCharter]"
+														tooltipwidget = {
+																ContextualTooltipType = {
+																blockoverride "title_text" {
+																	text = "COLONIAL_PROGRESS_POT_HEADER"
+																}
+
+																blockoverride "title_icon_texture" {
+																texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 3
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.3
+																	}
+																}
+
+																blockoverride "concept_link" {
+																	text = [colonial_charters|e]
+																}
+
+																blockoverride "tooltip_content" {
+																	TooltipStringPairList = {
+																		textcontext = "[ColonialCharterItem.GetInformation]"
+																	}
+																}
+															}
+														}
+														layoutpolicy_horizontal = expanding
+														text_single = {
+															layoutpolicy_horizontal = expanding
+															align = right
+															text = "[ColonialCharterItem.GetProvinceDefinition.GetNameWithNoTooltip]"
+														}
+														text_single = {
+															layoutpolicy_horizontal = expanding
+															align = right
+															text = "[ColonialCharterItem.GetNumLocations]"
+														}
+													}
+
+													icon = {
+														size = { 30 30 }
+														texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+														texture_density = 2
+														alpha = 1
+													}
+												}
+											}
+
+											vbox = {
+												visible = "[Not(EqualTo_string(Player.GetCountryTypeString, 'building'))]"
+												layoutpolicy_horizontal = expanding
+												margin = {8 8}
+												widget = {
+													visible = "[LocationView.ShowPossibleColonyWidget]"
+													layoutpolicy_horizontal = expanding
+													size = { -1 60 }
+													datacontext = "[LocationView.GetColonialCharter]"
+													possible_colony_item = {
+														blockoverride "colony_item_size"{
+															size = { 100% 100% }
+														}
+													}
+												}
+
+												widget = {
+													visible = "[LocationView.ShowCurrentColonyWidget]"
+													layoutpolicy_horizontal = expanding
+													size = { -1 60 }
+													datacontext = "[LocationView.GetColonialCharter]"
+													colonial_charter_item = {
+														blockoverride "colony_item_size"{
+															size = {100% 100%}
+														}
+														blockoverride "highlight_cost" {}
+														blockoverride "highlight_name" {}
+														blockoverride "highlight_migration" {}
+														blockoverride "highlight_progress" {}
+													}
+												}
+
+												vbox = {
+													layoutpolicy_horizontal = expanding
+													maximumsize = { -1 70 }
+													datamodel = "[LocationView.GetColonialCharters]"
+													item = {
+														widget = {
+															layoutpolicy_horizontal = expanding
+															size = {-1 60}
+															colonial_charter_item = {
+																blockoverride "colony_item_size"{
+																	size = {100% 100%}
+																}
+																blockoverride "highlight_cost" {}
+																blockoverride "highlight_name" {}
+																blockoverride "highlight_migration" {}
+																blockoverride "highlight_progress" {}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+
+									# BUILDINGS BREAKDOWN
+									vbox = {
+										name = "location_buildings"
+										layoutpolicy_horizontal = expanding
+										spacing = 3
+										datamodel = "[LocationView.GetPopTypes]"
+										# visible = "[GreaterThan_int32(LocationView.GetNumPopBuildings, '(int32)0')]"
+
+										item = {
+											location_conditions_item = {
+												blockoverride "location_conditions_card_visible" {
+													visible = "[ShowBuildingCardForLocation(LocationView.GetLocation, PopType.Self)]"
+												}
+
+												# blockoverride "location_conditions_header_color"{
+												# 	color = "[PopType.GetColor]"
+												# 	alpha = 0.7
+												# }
+
+												blockoverride "location_conditions_item_size" {
+													size = { -1 67 }
+												}
+
+												blockoverride "header_obj" {
+													# BUILD BUILDINGS
+													widget = {
+														size = { 70 -1 }
+														layoutpolicy_vertical = expanding
+														using = bg_building_card_colors
+														blockoverride "building_color" {
+															color = "[PopType.GetColor]"
+															alpha = 0.8
+															blend_mode = overlay
+														}
+														card_header_button_04 = {
+															allow_outside = yes
+															size = { 100% 100% }
+															action_tooltip = {
+																click_type = left
+																click_mode = single
+																on_action = "[OpenLateralViewWithParams('location_production', 'display = lists')]"
+																on_action = "[OpenLateralViewWithFilter('location_production', PopType.GetKey)]"
+																on_action = "[ShowLocationProductionView(LocationView.GetLocation.GetId, '(bool)no')]"
+																title = "MANAGE_BUILDINGS_POP_TYPE"
+															}
+
+															datacontext = "[LocationView.GetLocation]"
+															tooltipwidget = {
+																using = locationview_employed_tt
+															}
+
+															vbox = {
+																margin = { 3 4 }
+																spacing = 2
+																widget = {
+																	size = { 20 20 }
+																	using = bg_circle_piechart
+
+																	icon = {
+																		size = { 92% 92% }
+																		parentanchor = center
+																		position = {-1 0}
+																		texture = "[GetGraphicalCultureTextureForCountryPopType(PopType.Self, LocationView.GetLocation.GetOwner.Self)]"
+																		glow = {
+																			name = "drop_shadow"
+																			glow_radius = 3
+																			color = {0.0 0.0 0.0 1.0}
+																			alpha = 0.3
+																		}
+																	}
+																}
+
+																vbox = {
+																	layoutpolicy_horizontal = expanding
+																	spacing = 4
+																	margin = { 2 0 }
+																	datacontext = "[LocationView.GetLocation]"
+
+																	text_single = {
+																		visible = "[LocationView.GetPopTypeItem(PopType.Self).HasPop]"
+																		layoutpolicy_horizontal = expanding
+																		size = { -1 10 }
+																		autoresize = no
+																		align = center
+																		fontsize = 12
+																		raw_text = "[Location.GetExpectedUnEmployed(PopType.Self)] / [Location.GetTotalPopTypeSize(PopType.Self)|s]"
+																	}
+
+																	text_single = {
+																		visible = "[Not(LocationView.GetPopTypeItem(PopType.Self).HasPop)]"
+																		layoutpolicy_horizontal = expanding
+																		size = { -1 10 }
+																		autoresize = no
+																		align = center
+																		fontsize = 12
+																		raw_text = "[Location.GetTotalPopTypeSize(PopType.Self)|s]"
+																	}
+
+																	hbox = {
+																		layoutpolicy_horizontal = expanding
+																		margin = { 2 0 }
+
+																		progressbar = {
+																			visible = "[And(LocationView.GetPopTypeItem(PopType.Self).HasPop, GreaterThan_CFixedPoint(Location.GetExpectedUnEmployedValue(PopType.Self), '(CFixedPoint)0'))]"
+																			layoutpolicy_horizontal = expanding
+																			size = { -1 5 }
+																			using = progress_bar_green_blue_alt
+																			min = 0
+																			max = 1
+																			value = "[FixedPointToFloat(Location.GetUnEmployedPercentageWithConstruction(PopType.Self))]"
+																			direction = horizontal
+																		}
+	
+																		progressbar = {
+																			visible = "[And(LocationView.GetPopTypeItem(PopType.Self).HasPop, Not(GreaterThan_CFixedPoint(Location.GetExpectedUnEmployedValue(PopType.Self), '(CFixedPoint)0')))]"
+																			layoutpolicy_horizontal = expanding
+																			size = { -1 5 }
+																			using = progress_bar_red_blue_alt
+																			min = 0
+																			max = 1
+																			value = "[FixedPointToFloat(Location.GetUnEmployedPercentageWithConstruction(PopType.Self))]"
+																			direction = horizontal
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+
+												blockoverride "location_conditions_card_datamodel" {
+													datamodel = "[DataModelFirst(LocationView.GetLocationBuildings(PopType.Self),'(int32)9')]"
+												}
+
+												blockoverride "location_conditions_card_spacing" {
+													spacing = 3
+												}
+
+												blockoverride "location_conditions_card_item" {
+													widget = {
+														size = { 41 55 }
+														visible = "[LocationBuildingItem.IsBuildingForPopType(PopType.Self)]"
+														row_building_card = {}
+													}
+												}
+
+												blockoverride "location_conditions_card_extra_text" {
+													widget = {
+														layoutpolicy_vertical = expanding
+														size = { 45 55 }
+														vbox = {
+															vbox = {
+																extra_list = {
+																	visible = "[GreaterThan_int32(LocationView.GetNumPopTypeOwnedBuildings(PopType.Self), '(int32)9')]"
+																	blockoverride "extra_list_text_content" {
+																		raw_text = "+[Subtract_int32(LocationView.GetNumPopTypeOwnedBuildings(PopType.Self), '(int32)9')]"
+																	}
+																	blockoverride "extra_list_icon" {
+																		texture = "[GetConceptTexture('buildings')]"
+																		texture_density = 2
+																	}
+																	
+																	tooltipwidget = {
+																		ContextualTooltipType = {
+																			datacontext = "[LocationView.GetLocation]"
+																			blockoverride "title_text" {
+																				text = "LOCATION_POPTYPE_BUILDINGS"
+																			}
+		
+																			blockoverride "concept_link" {
+																				text = "[buildings|e]"
+																			}
+		
+																			blockoverride "title_icon" {
+																				icon = {
+																					using = tooltip_title_icon_size
+																					texture = "[GetGraphicalCultureTextureForCountryPopType(PopType.Self, LocationView.GetLocation.GetOwner.Self)]"
+																					modify_texture = {
+																						using = overlay_window_texture
+																						blend_mode = overlay
+																						alpha = 0.7
+																					}
+		
+																					modify_texture = {
+																						texture = "gfx/interface/buttons/buttons_texture.dds"
+																						texture_density = 2
+																						blend_mode = overlay
+																						alpha = 0.6
+																					}
+		
+																					glow = {
+																						name = "drop_shadow"
+																						glow_radius = 3
+																						color = {0.0 0.0 0.0 1.0}
+																						alpha = 0.4
+																					}
+																				}
+																			}
+		
+																			blockoverride "tooltip_content" {
+																				TooltipListBase = {
+																					TooltipListScrollArea = {
+																						blockoverride "block_scrollarea" {
+																							maximumsize = { -1 440 }
+																						}
+		
+																						blockoverride "scrollarea_content" {
+																							location_buildings_tooltip = {
+																								blockoverride "location_buildings_tooltip_datamodel" {
+																									datamodel = "[DataModelSkipFirst(LocationView.GetLocationBuildings(PopType.Self), '(int32)9')]"
+																								}
+																								blockoverride "location_buildings_tooltip_items_visible" {
+																									visible = "[And(LocationBuildingItem.IsBuildingForPopType(PopType.Self), Not(LocationBuildingItem.GetBuilding.GetType.IsForeign))]"
+																								}
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}	
+																
+																extra_list = {
+																	visible = "[GreaterThan_int32(LocationView.GetNumPopTypeBuildings(PopType.Self), '(int32)9')]"
+																	blockoverride "extra_list_text_content" {
+																		raw_text = "+[LocationView.GetNumPopTypeForeignBuildings(PopType.Self)]"
+																	}
+																	blockoverride "extra_list_icon" {
+																		texture = "gfx/interface/icons/flat_icons/balance/foreign_buildings.dds"
+																		texture_density = 2
+																	}
+																	
+																	tooltipwidget = {
+																		ContextualTooltipType = {
+																			blockoverride "title_text" {
+																				text = "game_concept_foreign_buildings"
+																			}
+			
+																			blockoverride "concept_link" {
+																				text = "[foreign_buildings|e]"
+																			}
+			
+																			blockoverride "title_icon" {
+																				icon = {
+																					using = tooltip_title_icon_size
+																					texture = "gfx/interface/icons/flat_icons/balance/foreign_buildings.dds"
+																				}
+																			}
+			
+																			blockoverride "tooltip_content" {
+																				TooltipListScrollArea = {
+																					blockoverride "block_scrollarea" {
+																						maximumsize = { -1 440 }
+																					}
+			
+																					blockoverride "scrollarea_content" {
+																						location_buildings_tooltip = {}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+				
+														}
+													}	
+												}
+											}
+										}
+									}
+									
+									# MARKET
+									widget = {
+										layoutpolicy_horizontal = expanding
+										size = { -1 70 }
+									
+										hbox = {
+											using = bg_market_card
+											using = bg_cabinet_card_frame
+									
+											market_card = {
+												datacontext = "[LocationView.GetLocation]"
+												datacontext = "[LocationView.GetLocation.GetMarket]"
+											}
+										}
+									}
+
+
+									# Possible Colony
+									# location_conditions_item = {
+									# 	blockoverride "location_conditions_card_visible" {
+									# 		visible = "[Or(LocationView.ShowColonialCharterListWidget, LocationView.ShowCurrentColonyWidget)]"
+									# 	}
+
+									# 	blockoverride "location_conditions_card_header" {
+									# 		#POSSIBLE COLONY
+									# 		card_header_action_button_01 = {
+									# 			datacontext = "[LocationView.GetColonialCharter]"
+									# 			allow_outside = yes
+									# 			size = { 100% 100% }
+									# 			visible = "[LocationView.ShowPossibleColonyWidget]"
+
+									# 			name = "create colonial charter button"
+									# 			title = "create_colonial_charter"
+									# 			actor = "[Player]"
+									# 			enabled = "[UIAction.IsEnabled]"
+									# 			left_action = {
+									# 				action_name = "create_colonial_charter"
+									# 				parameter = {
+									# 					parameter_name = "target"
+									# 					parameter_value = "[ColonialCharterItem.GetProvinceDefinition]"
+									# 				}
+									# 			}
+									# 			onmousehierarchyenter = "[PdxGuiWidget.SetHighlightProvinceDefinition(ColonialCharterItem.GetProvinceDefinition)]"
+
+									# 			tooltipwidget = {
+									# 				ContextualTooltipType = {
+									# 					blockoverride "title_icon"
+									# 					{
+									# 						icon = {
+									# 							using = tooltip_title_icon_size
+									# 							texture = "gfx/interface/icons/flat_icons/geopolitics/current_explorers.dds"
+
+									# 							glow = {
+									# 								name = "drop_shadow"
+									# 								glow_radius = 3
+									# 								color = {0.0 0.0 0.0 1.0}
+									# 								alpha = 0.3
+									# 							}
+									# 						}
+									# 					}
+
+									# 					datacontext = "[ColonialCharterItem.GetProvinceDefinition]"
+									# 					blockoverride "title_text" {
+									# 						text = "CREATE_COLONIAL_CHARTER_LOC"
+									# 					}
+
+									# 					blockoverride "concept_link" {
+									# 						text = "[colonial_charter|e]"
+									# 					}
+
+									# 					blockoverride "tooltip_content"	{
+									# 						TooltipTextBlock = {
+									# 							blockoverride "text" {
+									# 								text = "create_colonial_charter_desc_t"
+									# 							}
+									# 						}
+									# 						TooltipStringPairList = {
+
+									# 							blockoverride "field_background" {
+									# 								background = {
+									# 									visible = "[EqualTo_int32(PdxGuiWidget.GetIndexInDataModel, '(int32)0')]"
+									# 									using = bg_round_corners_up
+									# 									margin = { 3 0 }
+									# 								}
+									# 								background = {
+									# 									visible = "[Not(IsOdd_int32(PdxGuiWidget.GetIndexInDataModel))]"
+									# 									using = color_light_blue_texture
+									# 									alpha = 0.3
+									# 								}
+									# 							}
+									# 							textcontext = "create_colonial_charter_desc_content"
+									# 						}
+									# 						TooltipTextBlock = {
+									# 							visible = "[Not( StringIsEmpty(UIAction.GetConditions) )]"
+									# 							blockoverride "text" {
+									# 								text = "[UIAction.GetConditions]"
+									# 							}
+									# 						}
+									# 					}
+									# 				}
+									# 			}
+
+									# 			icon = {
+									# 				size = { 22 22 }
+									# 				parentanchor = center
+									# 				position = {-1 0}
+									# 				texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+									# 				glow = {
+									# 					name = "drop_shadow"
+									# 					glow_radius = 3
+									# 					color = {0.0 0.0 0.0 1.0}
+									# 					alpha = 0.3
+									# 				}
+									# 			}
+									# 		}
+
+									# 		#CURRENT CHARTER
+									# 		card_header_action_button_01 = {
+									# 			datacontext = "[LocationView.GetColonialCharter]"
+									# 			allow_outside = yes
+									# 			size = { 100% 100% }
+									# 			visible = "[LocationView.ShowCurrentColonyWidget]"
+
+									# 			default_format = "#color_white"
+									# 			name = "abandon charter button"
+									# 			title = "ABANDON_BUTTON"
+									# 			actor = "[Player]"
+									# 			right_click_and_hold_action = {
+									# 				action_name = "abandon_colonial_charter"
+									# 				parameter = {
+									# 					parameter_name = "target"
+									# 					parameter_value = "[ColonialCharterItem.GetColonialCharter]"
+									# 				}
+									# 			}
+
+									# 			onclick = "[ShowProvinceDefinition(ColonialCharterItem.GetProvinceDefinition)]"
+
+									# 			datacontext = "[ColonialCharterItem.GetColonialCharter]"
+									# 			tooltipwidget = {
+									# 				using = ColonialCharter_tooltip
+									# 			}
+
+									# 			icon = {
+									# 				size = { 22 22 }
+									# 				parentanchor = center
+									# 				position = {-1 0}
+									# 				texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+									# 				glow = {
+									# 					name = "drop_shadow"
+									# 					glow_radius = 3
+									# 					color = {0.0 0.0 0.0 1.0}
+									# 					alpha = 0.3
+									# 				}
+									# 			}
+									# 		}
+
+									# 		#OTHERS CHARTERS
+									# 		widget = {
+									# 			size = {100% 100%}
+									# 			visible = "[Not(Or(LocationView.ShowPossibleColonyWidget, LocationView.ShowCurrentColonyWidget))]"
+									# 			tooltip = "game_concept_colonial_charter"
+									# 			icon = {
+									# 				size = { 22 22 }
+									# 				parentanchor = center
+									# 				position = {-1 0}
+									# 				texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+									# 				glow = {
+									# 					name = "drop_shadow"
+									# 					glow_radius = 3
+									# 					color = {0.0 0.0 0.0 1.0}
+									# 					alpha = 0.3
+									# 				}
+									# 			}
+									# 		}
+									# 	}
+
+									# 	blockoverride "location_conditions_card_main_content" {
+									# 		hbox = {
+									# 			layoutpolicy_vertical = expanding
+									# 			spacing = 8
+									# 			widget = {
+									# 				visible = "[LocationView.ShowCurrentColonyWidget]"
+									# 				size = { 110 25 }
+									# 				datacontext = "[LocationView.GetColonialCharter]"
+									# 				using = bg_number_container_bckg
+									# 				blockoverride "number_container_alpha" {
+									# 					alpha = 0.5
+									# 				}
+									# 				blockoverride "number_container_color" {
+									# 					modify_texture = {
+									# 						using = color_bg_blue_texture
+									# 						blend_mode = multiply
+									# 					}
+									# 				}
+									# 				hbox = {
+									# 					datacontext = "[ColonialCharterItem.GetColonialCharter]"
+									# 					piechart = {
+									# 						using = bg_circle
+									# 						size = { 22 22 }
+									# 						using = piechart_angles
+									# 						using = bg_circle_piechart
+									# 						tooltipwidget = {
+									# 							using = colonial_charter_progress_tooltip
+									# 						}
+									# 						icon = {
+									# 							texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+									# 							size = { 97% 97% }
+									# 							parentanchor = center
+									# 							color = { 0 0 0 1 }
+									# 						}
+
+									# 						pieslice_no_highlight = {
+									# 							texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+									# 							value = "[ColonialCharterItem.GetProgress]"
+									# 							color = { 0.3 0.8 0.3 1 }
+									# 							alpha = 0.8
+									# 						}
+
+									# 						pieslice_no_highlight = {
+									# 							texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+									# 							value = "[Subtract_float('(float)100.0', ColonialCharterItem.GetProgress)]"
+									# 							color = { 0.8 0.3 0.3 1 }
+									# 							alpha = 0.8
+									# 						}
+
+									# 						icon = {
+									# 							size = { 61% 61% }
+									# 							parentanchor = center
+									# 							texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+									# 						}
+									# 					}
+
+									# 					country_flag_small = {
+									# 						datacontext = "[ColonialCharterItem.GetColonialCharter.GetOwner]"
+									# 					}
+
+									# 					text_single = {
+									# 						layoutpolicy_vertical = expanding
+									# 						size = { 40 -1 }
+									# 						autoresize = no
+									# 						align = center|nobaseline
+									# 						raw_text = "[ColonialCharterItem.GetColonialCharter.GetMonthlyMigration]@population!"
+									# 						tooltipwidget = {
+									# 							using = colonial_charter_migration_tooltip
+									# 						}
+									# 					}
+									# 				}
+									# 			}
+
+									# 			hbox = {
+									# 				layoutpolicy_horizontal = expanding
+									# 				spacing = 8
+									# 				datamodel = "[DataModelFirst(LocationView.GetColonialCharters,'(int32)2')]"
+									# 				item = {
+									# 					colonial_charter_small_item = {}
+									# 				}
+									# 			}
+									# 		}
+									# 	}
+
+									# 	blockoverride "location_conditions_card_extra_text" {
+									# 		text_single = {
+									# 			margin = {5 5}
+									# 			using = Font_Type_Headers
+									# 			raw_text = "+[Subtract_int32(GetDataModelSize(LocationView.GetColonialCharters), '(int32)2')]"
+									# 			align = nobaseline
+									# 			visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetColonialCharters), '(int32)2')]"
+									# 			using = bg_number_container_bckg
+									# 			tooltipwidget = {
+									# 				ContextualTooltipType = {
+									# 					blockoverride "title_text" {
+									# 						text = "game_concept_colonial_charter"
+									# 					}
+
+									# 					blockoverride "concept_link" {
+									# 						text = "[colonial_charter|e]"
+									# 					}
+
+									# 					blockoverride "title_icon" {
+									# 						icon = {
+									# 							using = tooltip_title_icon_size
+									# 							texture = "gfx/interface/icons/flat_icons/geopolitics/available_colonies.dds"
+
+									# 							glow = {
+									# 								name = "drop_shadow"
+									# 								glow_radius = 3
+									# 								color = {0.0 0.0 0.0 1.0}
+									# 								alpha = 0.4
+									# 							}
+									# 						}
+									# 					}
+
+									# 					blockoverride "tooltip_content" {
+									# 						TooltipListScrollArea = {
+									# 							blockoverride "block_scrollarea" {
+									# 								maximumsize = { -1 500 }
+									# 							}
+
+									# 							blockoverride "scrollarea_content" {
+									# 								fixedgridbox = {
+									# 									resizeparent = yes
+									# 									addcolumn = 480
+									# 									addrow = 55
+
+									# 									datamodel = "[LocationView.GetColonialCharters]"
+									# 									item = {
+									# 										colonial_charter_item = {
+									# 											blockoverride "colony_item_size"{
+									# 												size = {480 50}
+									# 											}
+									# 											blockoverride "highlight_cost" {
+									# 											}
+									# 											blockoverride "highlight_name" {
+									# 											}
+									# 											blockoverride "highlight_migration" {
+									# 											}
+									# 											blockoverride "highlight_progress" {
+									# 											}
+
+									# 										}
+									# 									}
+									# 								}
+									# 							}
+									# 						}
+									# 					}
+									# 				}
+									# 			}
+									# 			blockoverride "number_container_alpha" {
+									# 				alpha = 0.5
+									# 			}
+									# 			blockoverride "number_container_color" {
+									# 				modify_texture = {
+									# 					using = color_bg_blue_texture
+									# 					blend_mode = multiply
+									# 				}
+									# 			}
+									# 		}
+									# 	}
+									# }
+
+									# # DISEASES
+									# location_conditions_item = {
+									# 	blockoverride "location_conditions_card_visible" {
+									# 		visible = "[LocationView.ShowDisease]"
+									# 	}
+									# 	blockoverride "location_conditions_card_header_tooltip" {
+									# 		tooltip = "[disease|e]"
+									# 	}
+									# 	blockoverride "location_conditions_card_header_texture" {
+                					# 		texture = "gfx/interface/icons/map_modes/disease.dds"
+									# 	}
+
+									# 	blockoverride "location_conditions_card_main_content" {
+									# 		hbox = {
+									# 			layoutpolicy_vertical = expanding
+									# 			spacing = 7
+
+									# 			#DISEASES
+									# 			piechart = {
+									# 				datacontext = "[LocationView.GetLocation]"
+									# 				visible = "[LocationView.ShowDisease]"
+									# 				using = bg_circle
+									# 				size = { 22 22 }
+									# 				using = piechart_angles
+									# 				using = bg_circle_piechart
+									# 				tooltipwidget = {
+									# 					using = location_disease_tooltip
+									# 				}
+
+									# 				icon = {
+									# 					texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+									# 					size = { 97% 97% }
+									# 					parentanchor = center
+									# 					color = { 0 0 0 1 }
+									# 				}
+
+									# 				pieslice_no_highlight = {
+									# 					texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+									# 					value = "[FixedPointToFloat(LocationView.GetDiseasePercentage)]"
+									# 					color = { 0.3 0.8 0.3 1 }
+									# 					alpha = 0.8
+									# 				}
+
+									# 				pieslice_no_highlight = {
+									# 					texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+									# 					value = "[Subtract_float('(float)1.0', FixedPointToFloat(LocationView.GetDiseasePercentage))]"
+									# 					color = { 0.8 0.3 0.3 1 }
+									# 					alpha = 0.8
+									# 				}
+
+									# 				icon = {
+									# 					size = { 61% 61% }
+									# 					parentanchor = center
+									# 					texture = "[GetDiseaseIcon(LocationView.GetHigherPresenceDisease)]"
+									# 				}
+									# 			}
+									# 		}
+									# 	}
+
+									# 	blockoverride "location_conditions_card_extra_text" {}
+									# }
+
+									# # WORKS OF ART
+									# location_conditions_item = {
+									# 	blockoverride "location_conditions_card_visible" {
+									# 		visible = "[GreaterThan_int32(Location.GetNumWorksOfArt, '(int32)0')]"
+									# 	}
+
+									# 	blockoverride "location_conditions_card_header" {
+									# 		#POSSIBLE COLONY
+									# 		card_header_button_01 = {
+									# 			allow_outside = yes
+									# 			size = { 100% 100% }
+									# 			onclick = "[OpenLateralViewWithParams('country_culture', 'subtab = works_of_art')]"
+
+									# 			tooltipwidget = {
+									# 				using = location_art_tooltip
+
+									# 				blockoverride "tooltip_ui_action_block" {
+									# 					TooltipFunctionalBlock = {
+									# 						using = tooltip_left_click_template
+									# 						blockoverride "action_left_text" { text = "OPEN_WORKS_OF_ART_TAB" }
+									# 					}
+									# 				}
+									# 			}
+
+									# 			icon = {
+									# 				size = { 22 22 }
+									# 				parentanchor = center
+									# 				texture = "gfx/interface/icons/flat_icons/art_works.dds"
+									# 				glow = {
+									# 					name = "drop_shadow"
+									# 					glow_radius = 3
+									# 					color = {0.0 0.0 0.0 1.0}
+									# 					alpha = 0.3
+									# 				}
+									# 			}
+									# 		}
+									# 	}
+
+									# 	blockoverride "location_conditions_card_datamodel" {
+									# 		datamodel = "[DataModelFirst(Location.GetWorksOfArt,'(int32)13')]"
+									# 	}
+									# 	blockoverride "location_conditions_card_item" {
+
+									# 		widget = {
+									# 			size = { 30 30}
+									# 			background = {
+									# 				texture = "gfx/interface/icons/laws/background_frame.dds"
+									# 				texture_density = 2
+									# 				spriteType = corneredstretched
+									# 				spriteBorder = { 0 0 }
+
+									# 				modify_texture = {
+									# 					using = color_black_texture
+									# 					blend_mode = multiply
+									# 					alpha = 0.3
+									# 				}
+
+									# 				#GOLD QUALITY
+									# 				modify_texture = {
+									# 				visible = "[GreaterThanOrEqualTo_CFixedPoint(WorkOfArt.GetQuality, '(CFixedPoint)80')]"
+									# 					using = color_gold_texture
+									# 					alpha = 0.7
+									# 				}
+
+									# 				#SILVER QUALITY
+									# 				modify_texture = {
+									# 					visible = "[Between_CFixedPoint(WorkOfArt.GetQuality, '(CFixedPoint)50', '(CFixedPoint)80')]"
+									# 					using = color_silver_texture
+									# 					alpha = 0.5
+									# 				}
+
+									# 				#BRONZE QUALITY
+									# 				modify_texture = {
+									# 					visible = "[LessThanOrEqualTo_CFixedPoint(WorkOfArt.GetQuality, '(CFixedPoint)50')]"
+									# 					using = color_bronze_texture
+									# 					alpha = 1.5
+									# 				}
+									# 			}
+
+									# 			tooltipwidget = {
+									# 				using = WorkOfArt_tooltip
+									# 			}
+
+									# 			icon = {
+									# 				size = { 80% 80% }
+									# 				parentanchor = center
+									# 				texture ="[GetWorkOfArtIcon(WorkOfArt.GetDefinition)]"
+									# 			}
+									# 		}
+									# 	}
+
+									# 	blockoverride "location_conditions_card_extra_text" {
+									# 		text_single = {
+									# 			margin = {5 5}
+									# 			using = Font_Type_Headers
+									# 			raw_text = "+[Subtract_int32(GetDataModelSize(Location.GetWorksOfArt), '(int32)13')]"
+									# 			align = nobaseline
+									# 			visible = "[GreaterThan_int32(GetDataModelSize(Location.GetWorksOfArt), '(int32)13')]"
+									# 			using = bg_number_container_bckg
+									# 			tooltipwidget = {
+									# 				using = location_art_tooltip
+									# 			}
+									# 			blockoverride "number_container_alpha" {
+									# 				alpha = 0.5
+									# 			}
+									# 			blockoverride "number_container_color" {
+									# 				modify_texture = {
+									# 					using = color_bg_blue_texture
+									# 					blend_mode = multiply
+									# 				}
+									# 			}
+									# 		}
+									# 	}
+									# }
+
+									expand = {}
+								}
+							}
+						}
+					}
+				}
+
+				# MILITARY
+				vbox = {
+					visible = "[LocationView.Vars.HasValue( 'tab', 'military' )]"
+					layoutpolicy_horizontal = expanding
+					layoutpolicy_vertical = expanding
+					margin = { 5 5 }
+					spacing = 10
+
+					widget = { ### Tax and Food
+						layoutpolicy_horizontal = expanding
+						size = { -1 45 }
+						hbox = {
+							margin = { 10 0 }
+							hbox = {
+								layoutpolicy_horizontal = expanding
+								subheader_unified_icon = {
+									expand = {}
+									datacontext = "[LocationView.GetLocation]"
+									margin = { 0 0 }
+									tooltipwidget = {
+										using = location_warscore_tooltip
+									}
+									blockoverride "subheader_unified_icon_texture" {
+										texture = "gfx/interface/icons/location_icons/war_score.dds"
+										glow = {
+											name = "drop_shadow"
+											glow_radius = 3
+											color = {0.0 0.0 0.0 1.0}
+											alpha = 0.3
+										}
+									}
+
+									blockoverride "subheader_unified_top_text" {
+										text = "game_concept_war_score"
+										align = nobaseline
+									}
+									blockoverride "subheader_unified_bottom_text" {
+										text = "[LocationView.GetLocation.GetWarWorth|2]"
+										align = nobaseline
+									}
+								}
+
+								expand = {}
+							}
+
+							# FORT
+							header_button_left = {
+								size = {175 40}
+								onmousehierarchyenter = "[LocationView.EnableZocNeighboursHighlight(PdxGuiWidget.AccessSelf)]"
+								enabled = "[LocationView.IsShowFortsEnabled]"
+								datacontext = "[LocationView.GetLocation]"
+
+								action_tooltip = {
+									click_type = left
+									click_mode = single
+									title = "GARRISON_TOOLTIP_LEFT_CLICK"
+									on_action = "[LocationView.ShowForts]"
+									enabled = "[LocationView.IsShowFortsEnabled]"
+									visible = "[LocationView.IsShowFortsEnabled]"
+								}
+
+								tooltipwidget = {
+									using = Garrison_tooltip
+								}
+								blockoverride "header_button_icon_obj"	{
+									piechart = {
+										datacontext = "[LocationView.GetLocation]"
+										parentanchor = center
+										using = bg_circle
+										size = { 30 30 }
+										minimumsize = { 30 30 }
+										using = piechart_angles
+
+										background = {
+											texture = "gfx/interface/component_tiles/hud_corners/circle_background.dds"
+											texture_density = 2
+
+											alpha = 1
+											margin = { 2 2 }
+
+											# block "bg_color_circle" {
+												modify_texture = {
+													using = color_mid_blue_texture
+													alpha = 0.8
+												}
+
+											# }
+
+											modify_texture = {
+												texture = "gfx/interface/component_overlay/gold_overlay_circle.dds"
+												texture_density = 2
+												spriteType = stretched
+												spriteborder = { 250 250 }
+												blend_mode = overlay
+												alpha = 0.7
+											}
+										}
+
+										background = {
+											texture = "gfx/interface/component_tiles/hud_corners/circle_shadow.dds"
+											texture_density = 2
+											margin = { 5 5 }
+
+											alpha = 0.5
+										}
+
+										icon = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+											size = { 97% 97% }
+											parentanchor = center
+											color = { 0 0 0 1 }
+										}
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+											value = "[FixedPointToFloat(LocationView.GetLocation.GetGarrisonPercentage)]"
+											color = { 0.3 0.8 0.3 1 }
+											alpha = 0.8
+										}
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+											value = "[Subtract_float('(float)1.0', FixedPointToFloat(LocationView.GetLocation.GetGarrisonPercentage))]"
+											using = color_value_progress_gray
+										}
+
+										icon = {
+											size = { 22 22 }
+											parentanchor = center
+											texture = "[GetConceptTexture('fort')]"
+											texture_density = 2
+										}
+									}
+								}
+								blockoverride "header_button_text_layout" {
+									hbox = {
+										using = layoutpolicy_expanding
+										margin_left = 5
+										margin_right = 20
+
+										vbox = {
+											using = layoutpolicy_expanding
+											hbox = {
+												layoutpolicy_horizontal = expanding
+												text_single = {
+													align = left|nobaseline
+													text = "FORT_LEVEL_VAL"
+													fontsize = 13
+												}
+												expand = {}
+											}
+											hbox = {
+												layoutpolicy_horizontal = expanding
+												text_single = {
+													align = left|nobaseline
+													fontsize = 13
+													raw_text = "[LocationView.GetLocation.GetGarrison]/[LocationView.GetLocation.GetMaxGarrison]@army_strength!" #[LocationView.GetLocation.GetModifierValueWithCountryCapped('local_garrison_size','global_garrison_size_modifier')]"
+												}
+												expand = {}
+											}
+										}
+									}
+								}
+							}
+
+							hbox = {
+								tooltipmeta = {
+									texture = "gfx/interface/icons/location_icons/supply_limit.dds"
+								}
+								layoutpolicy_horizontal = expanding
+								expand = {}
+
+								subheader_unified_icon = {
+									blockoverride "mirror_layout" { righttoleft = yes }
+									margin = { 0 0 }
+
+									datacontext = "[LocationView.GetLocation]"
+
+									tooltipwidget = {
+										using = supply_limit_tooltip
+									}
+
+									blockoverride "subheader_unified_icon" {
+										piechart = {
+											size = { 32 32 }
+											using = piechart_angles
+											using = bg_circle_piechart
+											visible = "[And(Not(LocationView.GetLocation.IsHiddenByFoW), Not(GreaterThan_CFixedPoint(LocationView.GetLocation.GetUsedSupply, LocationView.GetLocation.GetSupplyLimit)))]"
+
+											pieslice_no_highlight = {
+												texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+												value = "[FixedPointToFloat(LocationView.GetLocation.GetUsedSupply)]"
+												color = { 1 1 1 1 }
+											}
+
+											pieslice_no_highlight = {
+												texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+												value = "[Subtract_float(FixedPointToFloat(LocationView.GetLocation.GetSupplyLimit), FixedPointToFloat(LocationView.GetLocation.GetUsedSupply))]"
+												color = { 1 1 1 1 }
+											}
+
+											icon = {
+												size = { 17 17 }
+												parentanchor = center
+												texture = "gfx/interface/icons/location_icons/supply_limit.dds"
+												glow = {
+													name = "drop_shadow"
+													glow_radius = 3
+													color = {0.0 0.0 0.0 1.0}
+													alpha = 0.3
+												}
+											}
+										}
+
+										piechart = {
+											size = { 32 32 }
+											using = piechart_angles
+											using = bg_circle_piechart
+											visible = "[And(Not(LocationView.GetLocation.IsHiddenByFoW), GreaterThan_CFixedPoint(LocationView.GetLocation.GetUsedSupply, LocationView.GetLocation.GetSupplyLimit))]"
+
+											pieslice_no_highlight = {
+												texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+												value = 1
+												color = { 1 1 1 1 }
+											}
+
+											icon = {
+												size = { 17 17 }
+												parentanchor = center
+												texture = "gfx/interface/icons/location_icons/supply_limit.dds"
+												glow = {
+													name = "drop_shadow"
+													glow_radius = 3
+													color = {0.0 0.0 0.0 1.0}
+													alpha = 0.3
+												}
+											}
+										}
+
+										icon = {
+											visible = "[LocationView.GetLocation.IsHiddenByFoW]"
+											size = { 32 32 }
+											texture = "gfx/interface/icons/location_icons/supply_limit.dds"
+											glow = {
+												name = "drop_shadow"
+												glow_radius = 3
+												color = {0.0 0.0 0.0 1.0}
+												alpha = 0.3
+											}
+										}
+									}
+									blockoverride "subheader_unified_top_text" {
+										text = "game_concept_supply_limit"
+										align = right|nobaseline
+									}
+									blockoverride "subheader_unified_bottom_text" {
+										datacontext = "[LocationView.GetLocation]"
+										raw_text = "[SelectLocalization(Location.IsHiddenByFoW, 'LOCATION_VIEW_USED_SUPPLY_IN_FOW', 'LOCATION_VIEW_USED_SUPPLY')]"
+										align = right|nobaseline
+									}
+								}
+							}
+						}
+					}
+
+					scrollarea = {
+						using = layoutpolicy_expanding
+						scrollbarpolicy_horizontal = always_off
+						scrollbarpolicy_vertical = as_needed
+
+						scrollbar_vertical = {
+							using = Scrollbar_Vertical
+						}
+
+						scrollwidget = {
+							vbox = {
+								layoutpolicy_horizontal = expanding
+								layoutpolicy_vertical = expanding
+								spacing = 10
+								margin_right = 10
+								datacontext = "[LocationView.GetLocation]"
+
+								# COUNTRIES WITH CORE, BUILDING BASED, OR POP BASED
+								location_conditions_item = {
+									blockoverride "location_conditions_card_visible" {
+										visible = "[Or3(Location.HasOwner, LocationView.HasBuildingBasedOwners, LocationView.HasPopBasedOwners)]"
+									}
+
+									blockoverride "header_size" { 
+										visible = "[Location.HasOwner]"
+										# size = { 75 -1 } # this is the width needed for showing the flag of owner as well
+										size = { 40 -1 }
+									}
+
+									blockoverride "location_conditions_card_header" {
+										widget = {
+											size = { 100% 100% }
+
+											tooltipwidget = {
+												using = location_core_tooltip
+											}
+
+											hbox = {
+												expand = {}
+
+												# INTEGRATION/CORE
+												widget = {
+													size = { 28 28 }
+
+													# NOT INTEGRATED
+													navigational_button_alt = {
+														visible = "[And(And(Not(Location.IsOccupied), And(Location.GetOwner.IsPlayer, Not(Location.IsCurrentlyBeingIntegrated))), Not(Location.IsIntegrated))]"
+														size = { 100% 100% }
+														parentanchor = center
+														using = bg_circle_alt_purple_02
+														blockoverride "navigational_bg" {
+															background = {
+																texture = "gfx/interface/component_tiles/square_tile.dds"
+																texture_density = 2
+																margin = {1 1}
+																modify_texture = {
+																	using = color_dark_blue_texture
+																	blend_mode = multiply
+																}
+															}
+														}
+														blockoverride "icon_texture" {
+															texture = "[GetIntegrationLevelIcon(Location.GetIntegrationLevel)]"
+															size = {55% 55%}
+															using = icon_gold_texture_alt
+														}
+														tooltipwidget = {
+															using = location_core_tooltip
+														}
+														action_tooltip = {
+															click_type = left
+															click_mode = single
+															title = "AUTOMATED_SYSTEM_CABINET_CLICK"
+															on_action = "[OpenLateralViewWithParams('government', 'tabcontent = cabinet')]"
+														}
+													}
+
+													# INTEGRATED
+													icon = {
+														visible = "[Or(Location.IsIntegrated, And(Not(Location.GetOwner.IsPlayer), Not(Location.IsCurrentlyBeingIntegrated)))]"
+														size = { 100% 100% }
+														parentanchor = center
+														texture = "[GetIntegrationLevelIcon(Location.GetIntegrationLevel)]"
+														alwaystransparent = no
+
+														tooltipwidget = {
+															using = location_core_tooltip
+														}
+
+														glow = {
+															name = "drop_shadow"
+															glow_radius = 3
+															color = {0.0 0.0 0.0 1.0}
+															alpha = 0.3
+														}
+													}
+
+													# BEING INTEGRATED
+													piechart = {
+														using = bg_circle
+														using = bg_circle_piechart
+														using = piechart_angles
+														size = {100% 100% }
+														parentanchor = center
+														tooltipwidget = {
+															using = location_core_tooltip
+														}
+														visible = "[And(Not(Location.IsOccupied), And(Location.HasOwner, Location.IsCurrentlyBeingIntegrated))]"
+
+														pieslice = {
+															texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+															value = "[Location.GetIntegrationProgressFloat]"
+															color = { 1 1 1 1 }
+														}
+
+														pieslice = {
+															texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+															value = "[Subtract_float('(float)100.0', Location.GetIntegrationProgressFloat)]"
+															color = { 1 1 1 1 }
+														}
+
+														icon = {
+															size = { 58% 58% }
+															parentanchor = center
+															texture = "[GetIntegrationLevelIcon(Location.GetIntegrationLevel)]"
+														}
+													}
+												}
+
+												# #OWNER FLAG
+												# widget = {
+												# 	size = { 36 24 }
+
+												# 	country_flag_small = {
+												# 		size = { 100% 100% }
+												# 		datacontext = "[Location.GetOwner]"
+												# 	}
+												# }
+												
+												expand = {}
+											}
+										}
+									}
+
+									blockoverride "location_conditions_card_main_content" {
+										spacing = 6
+
+										# CORES
+										hbox = {
+											visible = "[Not(IsDataModelEmpty(Location.GetCores))]"
+											# layoutpolicy_vertical = expanding
+											margin_right = 2
+											
+											hbox = {
+												using = bg_text_mask_container_brown
+												margin = {2 2}
+												widget = {
+													size = { 30 30 }
+
+													tooltipwidget = {
+														ContextualTooltipType = {
+															blockoverride "title_text" {
+																text = "[cores] in [Location.GetNameWithNoTooltip]"
+															}
+															blockoverride "title_icon" {
+																icon = {
+																	using = tooltip_title_icon_size
+																	texture = "gfx/interface/icons/integration_levels/core.dds"
+																}
+															}
+															blockoverride "concept_link" {
+																text = "[integration_status|e]"
+															}
+															blockoverride "tooltip_content" {
+																TooltipRowList = {
+																	textcontext = "[Location.GetCoresList]"
+																}
+															}
+														}
+													}
+
+													hbox = {
+														hbox = {
+															using = bg_card_header_01
+															margin = {2 2}
+															icon = {
+																size = { 21 21 }
+																texture = "gfx/interface/icons/integration_levels/core.dds"
+																glow = {
+																	name = "drop_shadow"
+																	glow_radius = 3
+																	color = {0.0 0.0 0.0 1.0}
+																	alpha = 0.3
+																}
+															}
+														}
+													}
+												}
+												flags_with_limit = {
+													visible = "[And(Not(LocationView.HasBuildingBasedOwners), Not(LocationView.HasPopBasedOwners))]"
+													blockoverride "flags_with_limit_datamodel"{
+														datamodel = "[DataModelFirst(Location.GetCores,'(int32)8')]"
+													}
+													blockoverride "flags_with_limit_text"{
+														raw_text = "+[Subtract_int32(GetDataModelSize(Location.GetCores), '(int32)8')]"
+													}
+													blockoverride "flags_with_limit_visible_extra"{
+														visible = "[GreaterThan_int32(GetDataModelSize(Location.GetCores), '(int32)8')]"
+													}
+												}
+												flags_with_limit = {
+													visible = "[Or(LocationView.HasBuildingBasedOwners, LocationView.HasPopBasedOwners)]"
+												}
+											}
+										}
+
+										# BUILDING BASED
+										hbox = {
+											visible = "[LocationView.HasBuildingBasedOwners]"
+											margin_right = 2
+											hbox = {
+												using = bg_text_mask_container_brown
+												margin = {2 2}
+												widget = {
+													size = { 30 30 }
+
+													tooltipwidget = {
+														using = ForeignBuildingsFlags_tooltip
+													}
+
+													hbox = {
+														hbox = {
+															using = bg_card_header_01
+															margin = {2 2}
+															icon = {
+																size = { 21 21 }
+																texture = "gfx/interface/icons/country_types/building.dds"
+																glow = {
+																	name = "drop_shadow"
+																	glow_radius = 3
+																	color = {0.0 0.0 0.0 1.0}
+																	alpha = 0.3
+																}
+															}
+														}
+													}
+												}
+												flags_with_limit = {
+													visible = "[And(IsDataModelEmpty(Location.GetCores), Not(LocationView.HasPopBasedOwners))]"
+													blockoverride "flags_with_limit_datamodel"{
+														datamodel = "[DataModelFirst(LocationView.GetBuildingBasedOwners,'(int32)8')]"
+													}
+													blockoverride "flags_with_limit_text"{
+														raw_text = "+[Subtract_int32(GetDataModelSize(LocationView.GetBuildingBasedOwners), '(int32)8')]"
+													}
+													blockoverride "flags_with_limit_visible_extra"{
+														visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetBuildingBasedOwners), '(int32)8')]"
+													}
+													blockoverride "flags_with_limit_tooltip_extra"{
+														tooltipwidget = {
+															using = ForeignBuildingsFlags_tooltip
+														}
+													}
+												}
+												flags_with_limit = {
+													visible = "[Or(Not(IsDataModelEmpty(Location.GetCores)), LocationView.HasPopBasedOwners)]"
+													blockoverride "flags_with_limit_datamodel"{
+														datamodel = "[DataModelFirst(LocationView.GetBuildingBasedOwners,'(int32)2')]"
+													}
+													blockoverride "flags_with_limit_text"{
+														raw_text = "+[Subtract_int32(GetDataModelSize(LocationView.GetBuildingBasedOwners), '(int32)2')]"
+													}
+													blockoverride "flags_with_limit_visible_extra"{
+														visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetBuildingBasedOwners), '(int32)2')]"
+													}
+													blockoverride "flags_with_limit_tooltip_extra"{
+														tooltipwidget = {
+															using = ForeignBuildingsFlags_tooltip
+														}
+													}
+												}
+											}
+										}
+
+										# POP BASED
+										hbox = {
+											layoutpolicy_vertical = expanding
+											visible = "[LocationView.HasPopBasedOwners]"
+											margin_right = 2
+
+											hbox = {
+												using = bg_text_mask_container_brown
+												margin = {2 2}
+												widget = {
+													size = { 30 30 }
+
+													tooltipwidget = {
+														using = CultureCountriesFlags_tooltip
+													}
+
+													hbox = {
+														hbox = {
+															using = bg_card_header_01
+															margin = {2 2}
+															icon = {
+																size = { 21 21 }
+																texture = "gfx/interface/icons/country_types/pop.dds"
+																glow = {
+																	name = "drop_shadow"
+																	glow_radius = 3
+																	color = {0.0 0.0 0.0 1.0}
+																	alpha = 0.3
+																}
+															}
+														}
+													}
+												}
+												flags_with_limit = {
+													visible = "[And(IsDataModelEmpty(Location.GetCores), Not(LocationView.HasBuildingBasedOwners))]"
+													blockoverride "flags_with_limit_datamodel"{
+														datamodel = "[DataModelFirst(LocationView.GetPopBasedOwners,'(int32)8')]"
+													}
+													blockoverride "flags_with_limit_text"{
+														raw_text = "+[Subtract_int32(GetDataModelSize(LocationView.GetPopBasedOwners), '(int32)8')]"
+													}
+													blockoverride "flags_with_limit_visible_extra"{
+														visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetPopBasedOwners), '(int32)8')]"
+													}
+													blockoverride "flags_with_limit_tooltip_extra"{
+														tooltipwidget = {
+															using = CultureCountriesFlags_tooltip
+														}
+													}
+												}
+												flags_with_limit = {
+													visible = "[Or(Not(IsDataModelEmpty(Location.GetCores)), LocationView.HasBuildingBasedOwners)]"
+													blockoverride "flags_with_limit_datamodel"{
+														datamodel = "[DataModelFirst(LocationView.GetPopBasedOwners,'(int32)2')]"
+													}
+													blockoverride "flags_with_limit_text"{
+														raw_text = "+[Subtract_int32(GetDataModelSize(LocationView.GetPopBasedOwners), '(int32)2')]"
+													}
+													blockoverride "flags_with_limit_visible_extra"{
+														visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetPopBasedOwners), '(int32)2')]"
+													}
+													blockoverride "flags_with_limit_tooltip_extra"{
+														tooltipwidget = {
+															using = CultureCountriesFlags_tooltip
+														}
+													}
+												}
+											}
+										}
+									}
+									
+									
+
+									# blockoverride "location_conditions_card_item" {
+									# 	hbox = {
+									# 		country_flag_small = {}
+									# 		# tooltipwidget = {
+									# 		# 	ContextualTooltipType = {
+									# 		# 		blockoverride "title_text" {
+									# 		# 			text = "[Location.GetIntegrationHeader]"
+									# 		# 		}
+									# 		# 		blockoverride "title_icon" {
+									# 		# 			icon = {
+									# 		# 				using = tooltip_title_icon_size
+									# 		# 				texture = "[GetIntegrationLevelIcon(Location.GetIntegrationLevelForCountry(Country.Self))]"
+									# 		# 			}
+									# 		# 		}
+									# 		# 		blockoverride "concept_link" {
+									# 		# 			text = [integration_status|e]
+									# 		# 		}
+									# 		# 		blockoverride "tooltip_content" {
+									# 		# 			TooltipTextBlock = {
+									# 		# 				visible = "[Location.IsCurrentlyBeingIntegrated]"
+
+									# 		# 				blockoverride "text" {
+									# 		# 					text = "LOCATION_INTEGRATION_TT_TEXT"
+									# 		# 				}
+									# 		# 			}
+									# 		# 			TooltipStringPairList = {
+									# 		# 				visible = "[Location.IsCurrentlyBeingIntegrated]"
+									# 		# 				textcontext = "[Location.GetIntegrationFinishedInfo]"
+									# 		# 			}
+
+									# 		# 			TooltipStringPairList = {
+									# 		# 				blockoverride "block_title" {
+									# 		# 					text = "LOCATION_INTEGRATION_TT_LIST"
+									# 		# 				}
+									# 		# 				textcontext = "[Location.GetCurrentIntegrationInfoForCountry(Country.Self)]"
+									# 		# 			}
+
+									# 		# 			TooltipRowList = {
+									# 		# 				textcontext = "[Location.GetCoresList]"
+									# 		# 			}
+									# 		# 		}
+									# 		# 	}
+									# 		# }
+									# 	}
+									# }
+
+									blockoverride "location_conditions_card_extra_text" {}
+								}
+
+								# BATTLE
+								battle_goto_widget = {
+									visible = "[LocationView.GetLocation.HasCombat]"
+									datacontext = "[LocationView.GetLocation.GetCombat]"
+								}
+
+								# OCCUPATION/SIEGE
+								vbox = {
+									visible = "[LocationView.GetLocation.HasSiege]"
+									layoutpolicy_horizontal = expanding
+
+									occupation_block = {
+										datacontext = "[LocationView.GetLocation.GetSiege]"
+									}
+
+									siege_block = {
+										datacontext = "[LocationView.GetLocation.GetSiege]"
+									}
+								}
+
+								# Armies in progress
+								location_conditions_item = {
+									visible = "[Location.HasOwner]"
+									blockoverride "location_conditions_item_size"{
+										size = { -1 80}
+									}
+
+									# blockoverride "location_conditions_header_color"{
+									# 	using = color_military_texture
+									# }
+
+									blockoverride "bg_card_header_01_bg"{
+										using = bg_card_header_01_military
+									}
+
+									blockoverride "location_conditions_card_header" {
+										card_header_button_01 = {
+											allow_outside = yes
+											size = { 100% 100% }
+											datacontext = "[LocationView.GetLocation]"
+											enabled = "[LocationView.CanBuildArmy]"
+
+											action_tooltip = {
+												title = "[LocationView.CanBuildArmyTT]"
+												enabled = "[LocationView.CanBuildArmy]"
+												on_action = "[ShowArmyBuilderViewWithLocation(Location.GetId)]"
+											}
+
+											tagtooltip_enabled = yes
+											tooltip = "[LocationView.GetLocation.GetModifierValue('max_regiments_trained_at_same_time')]"
+
+											vbox = {
+												spacing = 5
+
+												expand = {}
+												icon = {
+													size = { 22 22 }
+													texture = "gfx/interface/icons/modifier_types/max_regiments_trained_at_same_time.dds"
+													glow = {
+														name = "drop_shadow"
+														glow_radius = 3
+														color = {0.0 0.0 0.0 1.0}
+														alpha = 0.3
+													}
+												}
+
+												text_single = {
+													maximumsize = { 30 -1 }
+													align = center
+													text = "[LocationView.GetLocation.GetRoundedModifierValue('max_regiments_trained_at_same_time')|0G]"
+												}
+												expand = {}
+											}
+										}
+									}
+
+									blockoverride "location_conditions_card_main_content_margin" {
+										margin = { 0 0 }
+									}
+
+									blockoverride "location_conditions_card_main_content" {
+										vbox = {
+											using = layoutpolicy_expanding
+											widget = {
+												layoutpolicy_horizontal = expanding
+												size = { -1 35 }
+												using = bg_card_header_01_military
+
+												hbox = {
+													margin_left = 10
+													hbox = {
+														layoutpolicy_horizontal = expanding
+														text_single = {
+															layoutpolicy_horizontal = expanding
+															text = "ARMY_BUILDER"
+															align = nobaseline
+														}
+
+														expand = {}
+
+														hbox = {
+															spacing = 5
+
+															expand = {}
+
+															hbox = {
+																spacing = 4
+																margin = { 4 4 }
+																minimumsize = { 50 -1 }
+																using = bg_dark_paper_card
+																icon = {
+																	size = { 22 22 }
+																	texture = "gfx/interface/icons/location_icons/manpower.dds"
+																}
+																text_single = {
+																	text = "[LocationView.GetLocation.GetModifierValueWithCountryPercentAndLocalPercentNoFormat('local_manpower', 'local_manpower_modifier', 'global_manpower_modifier')]"
+																	align = nobaseline
+																	fontsize = 13
+																}
+																tagtooltip_enabled = yes
+																tooltip = "[LocationView.GetLocation.GetModifierValueAndPercentWithCountryPercent('local_manpower', 'local_manpower_modifier', 'global_manpower_modifier')]"
+															}
+
+															hbox = {
+																datacontext = "[LocationView.GetLocation]"
+																spacing = 4
+																margin = { 4 4 }
+																minimumsize = { 70 -1 }
+																using = bg_dark_paper_card
+
+																tooltipmeta = {
+																	texture = "gfx/interface/icons/unit_category/army_levies.dds"
+																	game_concept = "[army_levies|e]"
+																}
+																tooltipwidget = {
+																	using = location_army_levy_tt
+																}
+																piechart = {
+																	datacontext = "[LocationView.GetLocation]"
+																	size = { 22 22 }
+																	using = bg_circle
+																	using = bg_circle_piechart
+																	using = piechart_angles
+
+																	icon = {
+																		texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+																		size = { 97% 97% }
+																		parentanchor = center
+																		color = { 0 0 0 1 }
+																	}
+
+																	pieslice_no_highlight = {
+																		texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+																		value = "[FixedPointToFloat(LocationView.GetLocation.GetProvince.GetArmyLevyPercentage)]"
+																		filter_mouse = none
+																		alwaystransparent = yes
+																		color = { 0.3 0.8 0.3 1 }
+																		alpha = 0.8
+																	}
+
+																	pieslice_no_highlight = {
+																		texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+																		value = "[Subtract_float('(float)1.0', FixedPointToFloat(LocationView.GetLocation.GetProvince.GetArmyLevyPercentage))]"
+																		filter_mouse = none
+																		alwaystransparent = yes
+																		using = color_value_progress_gray
+																	}
+
+																	icon = {
+																		size = { 66% 66% }
+																		parentanchor = center
+																		texture = "gfx/interface/icons/unit_category/army_levies.dds"
+																	}
+																}
+																text_single = {
+																	text = "[GetTotalArmyLevySize(LocationView.GetLocation)]"
+																	align = nobaseline
+																	fontsize = 13
+																}
+															}
+														}
+													}
+
+													expand = {}
+
+													hbox = {
+														margin_left = 10
+														spacing = 5
+
+														# Levies
+														card_button_alt = {
+															enabled = "[CanRaiseArmyLevies(LocationView.GetLocation)]"
+
+															action_tooltip = {
+																title = "RAISE_ARMY_LEVIES_TT"
+																enabled = "[CanRaiseArmyLevies(LocationView.GetLocation)]"
+																on_action = "[RaiseArmyLevies(LocationView.GetLocation)]"
+															}
+
+															tooltipwidget = {
+																SimpleContextualTooltipType = {
+																	blockoverride "title_icon" {
+																		icon = {
+																			using = tooltip_title_icon_size
+																			texture = "gfx/interface/icons/unit_category/army_levies.dds"
+																		}
+																	}
+																	blockoverride "concept_link" {
+																		text = [levy|E]
+																	}
+																	blockoverride "title_button" { 
+																		hint_button = {
+																			action_tooltip = {
+																				title = "OPEN_HINT"
+																				on_action = "[OpenLateralViewWithParams('hints', 'selected_hint = hint_has_unraised_levies_in_war')]"
+																			}
+																		}
+																	}
+																	lowpriotextcontext =  "[LocationView.GetRaiseArmyLeviesTooltip]"
+																}
+															}
+
+															size = { 35 35 }
+
+															vbox = {
+																using = layoutpolicy_expanding
+																margin = { 0 5 }
+
+																icon = {
+																	size = {25 25}
+																	texture = "gfx/interface/icons/unit_category/army_levies.dds"
+
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 2
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.7
+																	}
+																}
+															}
+														}
+
+														# Regulars
+														card_button_alt = {
+															enabled = "[LocationView.CanBuildArmy]"
+															onclick = "[ShowArmyBuilderViewWithLocation(LocationView.GetLocation.GetId)]"
+															size = { 35 35 }
+
+															action_tooltip = {
+																title = "[LocationView.CanBuildArmyTT]"
+																enabled = "[LocationView.CanBuildArmy]"
+																description = "[SelectLocalization(LocationView.CanBuildArmy, 'LOCATION_VIEW_ARMY_BUILDER_CLICK', LocationView.CanBuildArmyTT)]"
+																on_action = "[ShowArmyBuilderViewWithLocation(LocationView.GetLocation.GetId)]"
+															}
+
+															tooltipwidget = {
+																using = LocationRegularsTooltip
+															}
+
+															vbox = {
+																using = layoutpolicy_expanding
+
+																icon = {
+																	size = {25 25}
+																	texture = "gfx/interface/icons/unit_actions/regulars.dds"
+
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 2
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.7
+																	}
+																}
+															}
+														}
+
+														# Mercenaries
+														card_button_alt = {
+															# visible = "[EqualTo_int32(ConstructionItem.GetPos, '(int32)2')]"
+															size = { 35 35 }
+															# enabled = "[And(Not(LocationView.GetLocation.HasCombat), Not(LocationView.GetLocation.HasSiege))]"
+															enabled = "[LocationView.CanBuildArmy]"
+
+															action_tooltip = {
+																title = "[SelectLocalization(LocationView.CanBuildArmy, 'CONSTRUCTION_MERCENARY_SIDEMENU_ARMY', LocationView.CanBuildArmyTT)]"
+																# enabled = "[And(Not(LocationView.GetLocation.HasCombat), Not(LocationView.GetLocation.HasSiege))]"
+																enabled = "[LocationView.CanBuildArmy]"
+																description = "[SelectLocalization(LocationView.CanBuildArmy, 'LOCATION_VIEW_ARMY_BUILDER_CLICK', LocationView.CanBuildArmyTT)]"
+																on_action = "[OpenLateralViewWithParams('army_builder', 'subtab = hiring | unit_type = army')]"
+															}
+
+															tooltipwidget = {
+																using = LocationMercenariesTooltip
+															}
+
+															vbox = {
+																using = layoutpolicy_expanding
+																# margin = { 0 5 }
+
+																icon = {
+																	size = {25 25}
+																	texture = "gfx/interface/icons/unit_category/mercenary.dds"
+
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 2
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.7
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											hbox = {
+												using = layoutpolicy_expanding
+												margin = { 5 0}
+												hbox = {
+													layoutpolicy_vertical = expanding
+													spacing = 4
+													datamodel = "[DataModelFirst(LocationView.GetInProgressArmyConstructions,'(int32)8')]"
+													item = {
+														army_small_item = {}
+													}
+												}
+
+												hbox = {
+													visible = "[And(GreaterThan_int32(LocationView.GetAvailableArmySlots, '(int32)0' ), LessThan_int32(GetDataModelSize(LocationView.GetInProgressArmyConstructions), '(int32)8'))]" 
+													datamodel = "[DataModelRepeatedItem(LocationView.GetVisibleAvailableArmySlots('(int32)5'))]"
+													item = {
+														army_slot = {}
+													}
+												}
+
+												expand = {}
+
+												text_single = {
+													margin = {5 5}
+													using = Font_Type_Headers
+													raw_text = "+[Subtract_int32(GetDataModelSize(LocationView.GetInProgressArmyConstructions), '(int32)8')]"
+													align = nobaseline
+													visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetInProgressArmyConstructions), '(int32)8')]"
+													using = bg_number_container_bckg
+													tooltipwidget = {
+														ContextualTooltipType = {
+															blockoverride "title_text" {
+																text = "ARMY_BUILDER"
+															}
+
+															blockoverride "concept_link" {
+																text = "[armies|e]"
+															}
+
+															blockoverride "title_icon" {
+																icon = {
+																	using = tooltip_title_icon_size
+																	texture = "gfx/interface/icons/diplomatic_status/war.dds"
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 3
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.4
+																	}
+																}
+															}
+
+															blockoverride "tooltip_content" {
+																TooltipListScrollArea = {
+																	blockoverride "block_scrollarea" {
+																		maximumsize = { -1 400 }
+																	}
+
+																	blockoverride "scrollarea_content" {
+																		vbox = {
+																			set_parent_dimension_to_minimum = height
+																			layoutpolicy_horizontal = expanding
+
+																			vbox = {
+																				layoutpolicy_horizontal = expanding
+																				datamodel = "[DataModelSkipFirst(LocationView.GetInProgressArmyConstructions, '(int32)5')]"
+																				item = {
+																					army_small_item = {}
+																				}
+																			}
+
+																			vbox = {
+																				visible = "[And(GreaterThan_int32(LocationView.GetAvailableArmySlots, '(int32)0' ), LessThan_int32(LocationView.GetVisibleAvailableArmySlots('(int32)5'), LocationView.GetAvailableArmySlots))]"
+																				layoutpolicy_vertical = expanding
+																				datamodel = "[DataModelRepeatedItem(Subtract_int32(LocationView.GetAvailableArmySlots, LocationView.GetVisibleAvailableArmySlots('(int32)5')))]"
+																				item = {
+																					army_slot = {}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													blockoverride "number_container_alpha" {
+														alpha = 0.5
+													}
+													blockoverride "number_container_color" {
+														modify_texture = {
+															using = color_bg_blue_texture
+															blend_mode = multiply
+														}
+													}
+												}
+												text_single = {
+													margin = {5 5}
+													using = Font_Type_Headers
+													raw_text = "[Subtract_int32(LocationView.GetAvailableArmySlots, LocationView.GetVisibleAvailableArmySlots('(int32)5'))]"
+													align = nobaseline
+													visible = "[And(Not(GreaterThan_int32(GetDataModelSize(LocationView.GetInProgressArmyConstructions), '(int32)8')), And(GreaterThan_int32(LocationView.GetAvailableArmySlots, '(int32)0' ), LessThan_int32(LocationView.GetVisibleAvailableArmySlots('(int32)5'), LocationView.GetAvailableArmySlots)))]"
+													using = bg_number_container_bckg
+													tooltipwidget = {
+														ContextualTooltipType = {
+															blockoverride "title_text" {
+																text = "ARMY_BUILDER"
+															}
+
+															blockoverride "concept_link" {
+																text = "[armies|e]"
+															}
+
+															blockoverride "title_icon" {
+																icon = {
+																	using = tooltip_title_icon_size
+																	texture = "gfx/interface/icons/diplomatic_status/war.dds"
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 3
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.4
+																	}
+																}
+															}
+
+															blockoverride "tooltip_content" {
+																TooltipListScrollArea = {
+																	blockoverride "block_scrollarea" {
+																		maximumsize = { -1 400 }
+																	}
+
+																	blockoverride "scrollarea_content" {
+																		vbox = {
+																			set_parent_dimension_to_minimum = height
+																			layoutpolicy_horizontal = expanding
+
+																			vbox = {
+																				visible = "[And(GreaterThan_int32(LocationView.GetAvailableArmySlots, '(int32)0' ), LessThan_int32(LocationView.GetVisibleAvailableArmySlots('(int32)5'), LocationView.GetAvailableArmySlots))]"
+																				layoutpolicy_vertical = expanding
+																				datamodel = "[DataModelRepeatedItem(Subtract_int32(LocationView.GetAvailableArmySlots, LocationView.GetVisibleAvailableArmySlots('(int32)5')))]"
+																				item = {
+																					army_slot = {}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													blockoverride "number_container_alpha" {
+														alpha = 0.5
+													}
+													blockoverride "number_container_color" {
+														modify_texture = {
+															using = color_bg_blue_texture
+															blend_mode = multiply
+														}
+													}
+												}
+											}
+										}
+									}
+
+									blockoverride "location_conditions_card_extra_text" {}
+								}
+
+								# Navies in progress
+								location_conditions_item = {
+									visible = "[And(Location.IsCoastal, Location.HasOwner)]"
+									blockoverride "location_conditions_item_size"{
+										size = { -1 80}
+									}
+
+									# blockoverride "location_conditions_header_color"{
+									# 	using = color_military_texture
+									# }
+
+									blockoverride "bg_card_header_01_bg"{
+										using = bg_card_header_01_military
+									}
+
+									blockoverride "location_conditions_card_header" {
+										card_header_button_01 = {
+											allow_outside = yes
+											size = { 100% 100% }
+											datacontext = "[LocationView.GetLocation]"
+											enabled = "[LocationView.CanBuildNavy]"
+
+											action_tooltip = {
+												title = "[LocationView.CanBuildNavyTT]"
+												enabled = "[LocationView.CanBuildNavy]"
+												on_action = "[ShowNavyBuilderViewWithLocation(LocationView.GetLocation.GetId)]"
+											}
+
+											tagtooltip_enabled = yes
+											tooltip = "[LocationView.GetLocation.GetModifierValue('max_ships_built_at_same_time')]"
+
+											vbox = {
+												spacing = 5
+
+												expand = {}
+												icon = {
+													size = { 22 22 }
+													texture = "gfx/interface/icons/modifier_types/max_ships_built_at_same_time.dds"
+													glow = {
+														name = "drop_shadow"
+														glow_radius = 3
+														color = {0.0 0.0 0.0 1.0}
+														alpha = 0.3
+													}
+												}
+
+												text_single = {
+													maximumsize = { 30 -1 }
+													align = center
+													text = "[LocationView.GetLocation.GetRoundedModifierValue('max_ships_built_at_same_time')|0G]"
+												}
+												expand = {}
+											}
+										}
+									}
+
+									blockoverride "location_conditions_card_main_content_margin" {
+										margin = { 0 0 }
+									}
+
+									blockoverride "location_conditions_card_main_content" {
+										vbox = {
+											using = layoutpolicy_expanding
+											widget = {
+												layoutpolicy_horizontal = expanding
+												size = { -1 35 }
+												using = bg_card_header_01_military
+
+												hbox = {
+													margin_left = 10
+													layoutpolicy_horizontal = expanding
+													hbox = {
+														layoutpolicy_horizontal = expanding
+														hbox = {
+															layoutpolicy_horizontal = expanding
+															spacing = 4
+															text_single = {
+																# layoutpolicy_horizontal = expanding
+																text = "NAVY_BUILDER"
+																align = nobaseline
+															}
+
+															expand = {}
+														}
+
+														expand = {}
+
+														hbox = {
+															spacing = 5
+
+															expand = {}
+
+															hbox = {
+																spacing = 4
+																margin = { 4 4 }
+																minimumsize = { 50 -1 }
+																using = bg_dark_paper_card
+																icon = {
+																	size = { 22 22 }
+																	texture = "gfx/interface/icons/location_icons/sailors.dds"
+																}
+																text_single = {
+																	text = "[LocationView.GetLocation.GetModifierValueWithCountryPercentAndLocalPercentNoFormat('local_sailors', 'local_sailors_modifier', 'global_sailors_modifier')]"
+																	align = nobaseline
+																	fontsize = 13
+																}
+																tagtooltip_enabled = yes
+																tooltip = "[LocationView.GetLocation.GetModifierValueAndPercentWithCountryPercent('local_sailors', 'local_sailors_modifier', 'global_sailors_modifier')]"
+															}
+
+															hbox = {
+																datacontext = "[LocationView.GetLocation]"
+																spacing = 4
+																margin = { 4 4 }
+																minimumsize = { 70 -1 }
+																using = bg_dark_paper_card
+
+																datacontext = "[LocationView.GetLocation]"
+																tooltipwidget = {
+																	using = location_navy_levy_tt
+																}
+																piechart = {
+																	datacontext = "[LocationView.GetLocation]"
+																	size = { 22 22 }
+																	using = bg_circle
+																	using = bg_circle_piechart
+																	using = piechart_angles
+
+																	icon = {
+																		texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+																		size = { 97% 97% }
+																		parentanchor = center
+																		color = { 0 0 0 1 }
+																	}
+
+																	pieslice_no_highlight = {
+																		texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+																		value = "[FixedPointToFloat(LocationView.GetLocation.GetProvince.GetNavyLevyPercentage)]"
+																		filter_mouse = none
+																		alwaystransparent = yes
+																		color = { 0.3 0.8 0.3 1 }
+																		alpha = 0.8
+																	}
+
+																	pieslice_no_highlight = {
+																		texture = "gfx/interface/pie_charts/pie_chart_alpha_80.dds"
+																		value = "[Subtract_float('(float)1.0', FixedPointToFloat(LocationView.GetLocation.GetProvince.GetNavyLevyPercentage))]"
+																		filter_mouse = none
+																		alwaystransparent = yes
+																		using = color_value_progress_gray
+																	}
+
+																	icon = {
+																		size = { 66% 66% }
+																		parentanchor = center
+																		texture = "gfx/interface/icons/unit_category/navy_levies.dds"
+																	}
+																}
+																text_single = {
+																	text = "[GetTotalNavyLevySize(LocationView.GetLocation)]"
+																	align = nobaseline
+																	fontsize = 13
+																}
+															}
+														}
+													}
+
+													expand = {}
+
+													hbox = {
+														margin_left = 10
+														spacing = 5
+														# Navy Levies
+														card_button_alt = {
+															size = { 35 35 }
+															enabled = "[CanRaiseNavyLevies(LocationView.GetLocation)]"
+
+															action_tooltip = {
+																title = "RAISE_NAVY_LEVIES_TT"
+																enabled = "[CanRaiseNavyLevies(LocationView.GetLocation)]"
+																on_action = "[RaiseNavyLevies(LocationView.GetLocation)]"
+															}
+
+															tooltipwidget = {
+																SimpleContextualTooltipType = {
+																	blockoverride "title_icon" {
+																		icon = {
+																			using = tooltip_title_icon_size
+																			texture = "gfx/interface/icons/unit_category/navy_levies.dds"
+																		}
+																	}
+
+																	blockoverride "concept_link" {
+																		text = [levy|E]
+																	}
+
+																	blockoverride "title_button" { 
+																		hint_button = {
+																			action_tooltip = {
+																				title = "OPEN_HINT"
+																				on_action = "[OpenLateralViewWithParams('hints', 'selected_hint = hint_has_unraised_levies_in_war')]"
+																			}
+																		}
+																	}
+																	lowpriotextcontext =  "[LocationView.GetRaiseNavyLeviesTooltip]"
+																}
+															}
+
+															vbox = {
+																using = layoutpolicy_expanding
+																margin = { 0 5 }
+
+																icon = {
+																	size = {25 25}
+																	texture = "gfx/interface/icons/unit_category/navy_levies.dds"
+
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 2
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.7
+																	}
+																}
+															}
+														}
+
+														# Navy Regulars
+														card_button_alt = {
+															size = { 35 35 }
+															enabled = "[LocationView.CanBuildNavy]"
+
+															action_tooltip = {
+																title = "[LocationView.CanBuildNavyTT]"
+																enabled = "[LocationView.CanBuildNavy]"
+																# description = "[SelectLocalization(LocationView.CanBuildArmy, 'LOCATION_VIEW_ARMY_BUILDER_CLICK', LocationView.CanBuildArmyTT)]"
+																on_action = "[ShowNavyBuilderViewWithLocation(LocationView.GetLocation.GetId)]"
+															}
+
+															tooltipwidget = {
+																using = LocationShipsTooltip
+															}
+
+															vbox = {
+																using = layoutpolicy_expanding
+																# margin = { 0 5 }
+
+																icon = {
+																	size = {25 25}
+																	texture = "gfx/interface/icons/unit_category/regulars_navy.dds"
+
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 2
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.7
+																	}
+																}
+															}
+														}
+
+														# Navy Mercenaries
+														card_button_alt = {
+															size = { 35 35 }
+															enabled = "[LocationView.CanBuildArmy]"
+															# enabled = "[And(Not(LocationView.GetLocation.HasCombat), Not(LocationView.GetLocation.HasSiege))]"
+															datacontext = "[LocationView.GetLocation]"
+															tooltipwidget = {
+																using = LocationNavalMercenariesTooltip
+																blockoverride "onclick_text" {
+																	text = "[SelectLocalization(LocationView.CanBuildArmy, 'CONSTRUCTION_MERCENARY_SIDEMENU_NAVY', LocationView.CanBuildArmyTT)]"
+																}
+															}
+															onclick = "[OpenLateralViewWithParams('army_builder', 'subtab = hiring | unit_type = navy')]"
+
+															vbox = {
+																using = layoutpolicy_expanding
+																# margin = { 0 5 }
+
+																icon = {
+																	size = {25 25}
+																	texture = "gfx/interface/icons/unit_category/mercenary_navy.dds"
+
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 2
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.7
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+											hbox = {
+												using = layoutpolicy_expanding
+												margin = { 5 0}
+												hbox = {
+													layoutpolicy_vertical = expanding
+													spacing = 4
+													datamodel = "[DataModelFirst(LocationView.GetInProgressNavyConstructions,'(int32)8')]"
+													item = {
+														army_small_item = {
+															datacontext = "[ConstructionItem.GetConstruction]"
+															blockoverride "army_small_item_visible" {
+																visible = "[GreaterThan_int32(ConstructionItem.GetPos, LocationView.GetNumTotalNavyStaticButtons)]"
+															}
+															# blockoverride "army_small_item_bg"{
+															# 	background = {
+															# 		using = bg_card_header_01_default
+															# 		blockoverride "header_color" {
+															# 			using = color_mid_blue_texture
+															# 			alpha = 0.9
+															# 		}
+
+															# 	}
+															# }
+															blockoverride "army_small_item_value"{
+																text = "CONSTRUCTION_DURATION_DAYS"
+															}
+														}
+													}
+												}
+
+												hbox = {
+													visible = "[And(GreaterThan_int32(LocationView.GetAvailableNavySlots, '(int32)0' ), LessThan_int32(GetDataModelSize(LocationView.GetInProgressNavyConstructions), '(int32)8'))]" 
+													datamodel = "[DataModelRepeatedItem(LocationView.GetVisibleAvailableNavySlots('(int32)5'))]"
+													item = {
+														navy_slot = {}
+													}
+												}
+
+												expand = {}
+
+												text_single = {
+													margin = {5 5}
+													using = Font_Type_Headers
+													raw_text = "+[Subtract_int32(GetDataModelSize(LocationView.GetInProgressNavyConstructions), '(int32)8')]"
+													align = nobaseline
+													visible = "[GreaterThan_int32(GetDataModelSize(LocationView.GetInProgressNavyConstructions), '(int32)8')]"
+													using = bg_number_container_bckg
+													tooltipwidget = {
+														ContextualTooltipType = {
+															blockoverride "title_text" {
+																text = "NAVY_BUILDER"
+															}
+
+															blockoverride "concept_link" {
+																text = "[navies|e]"
+															}
+
+															blockoverride "title_icon" {
+																icon = {
+																	using = tooltip_title_icon_size
+																	texture = "gfx/interface/icons/modifier_types/max_ships_built_at_same_time.dds"
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 3
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.4
+																	}
+																}
+															}
+
+															blockoverride "tooltip_content" {
+																TooltipListScrollArea = {
+																	blockoverride "block_scrollarea" {
+																		maximumsize = { -1 400 }
+																	}
+
+																	blockoverride "scrollarea_content" {
+																		vbox = {
+																			set_parent_dimension_to_minimum = height
+																			layoutpolicy_horizontal = expanding
+																			vbox = {
+																				layoutpolicy_vertical = expanding
+																				datamodel = "[DataModelSkipFirst(LocationView.GetInProgressNavyConstructions, '(int32)8')]"
+																				item = {
+																					army_small_item = {
+																						blockoverride "army_small_item_visible" {
+																							visible = "[GreaterThan_int32(ConstructionItem.GetPos, LocationView.GetNumTotalNavyStaticButtons)]"
+																						}
+																					}
+																				}
+																			}
+
+																			vbox = {
+																				visible = "[And(GreaterThan_int32(LocationView.GetAvailableNavySlots, '(int32)0' ), LessThan_int32(LocationView.GetVisibleAvailableNavySlots('(int32)5'), LocationView.GetAvailableNavySlots))]"
+																				layoutpolicy_vertical = expanding
+																				datamodel = "[DataModelRepeatedItem(Subtract_int32(LocationView.GetAvailableNavySlots, LocationView.GetVisibleAvailableNavySlots('(int32)5')))]"
+																				item = {
+																					navy_slot = {}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													blockoverride "number_container_alpha" {
+														alpha = 0.5
+													}
+													blockoverride "number_container_color" {
+														modify_texture = {
+															using = color_bg_blue_texture
+															blend_mode = multiply
+														}
+													}
+												}
+												text_single = {
+													margin = {5 5}
+													using = Font_Type_Headers
+													raw_text = "[Subtract_int32(LocationView.GetAvailableNavySlots, LocationView.GetVisibleAvailableNavySlots('(int32)5'))]"
+													align = nobaseline
+													visible = "[And(Not(GreaterThan_int32(GetDataModelSize(LocationView.GetInProgressNavyConstructions), '(int32)8')), And(GreaterThan_int32(LocationView.GetAvailableNavySlots, '(int32)0' ), LessThan_int32(LocationView.GetVisibleAvailableNavySlots('(int32)5'), LocationView.GetAvailableNavySlots)))]"
+													using = bg_number_container_bckg
+													tooltipwidget = {
+														ContextualTooltipType = {
+															blockoverride "title_text" {
+																text = "NAVY_BUILDER"
+															}
+
+															blockoverride "concept_link" {
+																text = "[navies|e]"
+															}
+
+															blockoverride "title_icon" {
+																icon = {
+																	using = tooltip_title_icon_size
+																	texture = "gfx/interface/icons/modifier_types/max_ships_built_at_same_time.dds"
+																	glow = {
+																		name = "drop_shadow"
+																		glow_radius = 3
+																		color = {0.0 0.0 0.0 1.0}
+																		alpha = 0.4
+																	}
+																}
+															}
+
+															blockoverride "tooltip_content" {
+																TooltipListScrollArea = {
+																	blockoverride "block_scrollarea" {
+																		maximumsize = { -1 400 }
+																	}
+
+																	blockoverride "scrollarea_content" {
+																		vbox = {
+																			set_parent_dimension_to_minimum = height
+																			layoutpolicy_horizontal = expanding
+																			vbox = {
+																				visible = "[And(GreaterThan_int32(LocationView.GetAvailableNavySlots, '(int32)0' ), LessThan_int32(LocationView.GetVisibleAvailableNavySlots('(int32)5'), LocationView.GetAvailableNavySlots))]"
+																				layoutpolicy_vertical = expanding
+																				datamodel = "[DataModelRepeatedItem(Subtract_int32(LocationView.GetAvailableNavySlots, LocationView.GetVisibleAvailableNavySlots('(int32)5')))]"
+																				item = {
+																					navy_slot = {}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+													blockoverride "number_container_alpha" {
+														alpha = 0.5
+													}
+													blockoverride "number_container_color" {
+														modify_texture = {
+															using = color_bg_blue_texture
+															blend_mode = multiply
+														}
+													}
+												}
+											}
+										}
+									}
+
+									blockoverride "location_conditions_card_extra_text" {}
+								}
+
+								expand = {}
+							}
+						}
+					}
+				}
+
+				# DEMOGRAPHY
+				vbox = {
+					visible = "[LocationView.Vars.HasValue( 'tab', 'demography' )]"
+					layoutpolicy_horizontal = expanding
+					layoutpolicy_vertical = expanding
+					margin_top = 5
+
+					widget = {
+						layoutpolicy_horizontal = expanding
+						size = { -1 45 }
+						hbox = {
+							subheader_unified_icon = {
+								datacontext = "[LocationView.GetLocation]"
+								tooltipwidget = { using = yearly_pop_growth_tooltip	}
+								blockoverride "subheader_unified_icon_texture" {
+									texture = "[GetConceptTexture('population_growth')]"
+								}
+								blockoverride "subheader_unified_top_text" {
+									text = "game_concept_population_growth"
+									align = nobaseline
+								}
+								blockoverride "unified_icon_bottom_content" {
+									spacing = 10
+									text_single = {
+										fontsize = 13
+										align = right|nobaseline	
+										text = "[LocationView.GetLocation.GetPopGrowth|2+=%]"
+									}
+									text_single = {
+										datacontext = "[LocationView.GetLocation]"
+										tooltipmeta = {
+											texture = "[GetConceptTexture('population_growth')]"
+											game_concept = "[population_growth|E]"
+										}
+										fontsize = 13
+										align = right|nobaseline
+										raw_text = "|  [LocationView.GetLocation.GetPopulationChangeLabel]@population!"
+										tooltip = "[Location.GetPopulationChangeLabel]"
+										tagtooltip_enabled = yes
+									}
+								}
+								
+							}
+				
+							expand = {}
+
+							# DEMOGRAPHY SHORTCUT
+							navigational_button_alt = {
+								size = {38 38}
+
+								blockoverride "icon_texture" {
+									piechart = {
+										parentanchor = center
+										size = { 70% 70% }
+										alwaystransparent = yes
+
+										using = piechart_angles
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+											value = "[FixedPointToFloat(Location.GetAverageSatisfaction)]"
+											color = { 1 1 1 1 }
+											alwaystransparent = yes
+										}
+
+										pieslice_no_highlight = {
+											texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+											value = "[Subtract_float('(float)1.0', FixedPointToFloat(Location.GetAverageSatisfaction))]"
+											color = { 1 1 1 1 }
+											alwaystransparent = yes
+										}
+
+										hbox = {
+											widget = {
+												using = layoutpolicy_expanding
+												icon = {
+													size = { 61% 61% }
+													parentanchor = center
+													name = "sad face"
+													visible = "[LessThanOrEqualTo_CFixedPoint(Location.GetAverageSatisfaction,'(CFixedPoint)0.25')]"
+													texture = "gfx/interface/icons/flat_icons/sad.dds"
+													texture_density = 2
+												}
+
+												icon = {
+													size = { 61% 61% }
+													parentanchor = center
+													name = "neutral face"
+													visible = "[BetweenInclusiveOfMax_CFixedPoint(Location.GetAverageSatisfaction,'(CFixedPoint)0.25', '(CFixedPoint)0.5')]"
+													texture = "gfx/interface/icons/flat_icons/neutral.dds"
+													texture_density = 2
+												}
+
+												icon = {
+													size = { 61% 61% }
+													parentanchor = center
+													name = "happy face"
+													visible = "[GreaterThan_CFixedPoint(Location.GetAverageSatisfaction,'(CFixedPoint)0.5')]"
+													texture = "gfx/interface/icons/flat_icons/happy.dds"
+													texture_density = 2
+												}
+											}
+										}
+										using = bg_circle_piechart
+									}
+								}
+
+								tooltipwidget = {
+									using = AverageSatisfaction_tooltip
+								}
+
+								action_tooltip = {
+									click_type = left
+									click_mode = single
+									title = "OPEN_PEOPLE_VIEW"
+									on_action = "[ShowCountryPeopleViewWithLocation(Location.GetId, '(bool)yes')]"
+								}
+							}
+
+							expand = {}
+				
+							subheader_unified_icon = {
+								blockoverride "mirror_layout" { righttoleft = yes }
+								tooltipwidget = {
+									using = MigrationAttraction_tooltip
+								}
+								blockoverride "subheader_unified_icon_texture" {
+									texture = "[GetConceptTexture('migration_attraction')]"
+								}
+								blockoverride "subheader_unified_top_text" {
+									text = "game_concept_migration_attraction"
+									align = right|nobaseline
+								}
+
+								blockoverride "unified_icon_bottom_content" {
+									spacing = 10
+									text_single = {
+										fontsize = 13
+										align = right|nobaseline	
+										text = "[LocationView.GetLocation.GetLocalMigrationAttraction]"
+									}
+									text_single = {
+										fontsize = 13
+										align = right|nobaseline
+										raw_text = "[LocationView.GetLocation.GetMigrationChange]@population!   |"
+										visible = "[Not(StringIsEmpty(LocationView.GetLocation.GetMigrationInformation))]"
+									}
+								}
+							}
+						}
+					}
+
+					# culture and religion
+					widget = {
+						using = layoutpolicy_expanding
+
+						vbox = {
+							margin = { 10 5 }
+							margin_bottom = 15
+							spacing = 5
+
+							# population
+							vbox = {
+								using = layoutpolicy_expanding
+								maximumsize = "[V2SizeHeight('(float)8.0', GetDataModelSize(LocationView.GetPops), '(float)32.0')]"
+
+								demography_chart = {
+									using = layoutpolicy_expanding
+
+									blockoverride "piechart_block" {
+										layoutpolicy_vertical = expanding
+										margin = { 0 3 }
+										spacing = 3
+										minimumsize = { 90 -1 }
+
+										hbox = {
+											datacontext = "[LocationView.GetLocation]"
+											layoutpolicy_horizontal = expanding
+											using = bg_number_container_bckg
+											blockoverride "number_container_extra" {
+												margin = {-2 -2}
+												alpha = 0.4
+											}
+											using = bg_frame_squared_brown
+
+											margin = { 5 5 }
+
+											hbox = {
+												spacing = 5
+												icon = {
+													size = { 28 28 }
+													texture = "gfx/interface/icons/location_icons/promotion.dds"
+													texture_density = 2
+												}
+
+												vbox = {
+													maximumsize = { 30 -1 }
+													text_single = {
+														align = left|nobaseline
+														fontsize = 14
+														maximumsize = { 30 -1 }
+														text = "[LocationView.GetLocation.GetPromote]"
+													}
+												}
+											}
+											datacontext = "[LocationView.GetLocation]"
+
+											tooltipwidget = {
+												using = location_promotion_tooltip
+											}
+										}
+
+										widget = {
+											using = layoutpolicy_expanding
+											vbox = {
+												using = bg_number_container_bckg
+												blockoverride "number_container_extra" {
+													margin = {-2 -2}
+													alpha = 0.4
+												}
+												using = bg_frame_squared_brown
+												icon_pie_left = {
+													blockoverride "PieSize" { size = { 50 50 } }
+													blockoverride "pie_datamodel" {
+														datamodel = "[LocationView.GetProvincePopTypes]"
+													}
+
+													###Slices and Icon
+													blockoverride "SliceTooltip" {
+														datacontext = "[LocationView.GetLocation]"
+														datacontext = "[Location.GetPopulationChart.GetPopsPiechartWidget]"
+														tooltipwidget = {
+															using = LocationPopulationTooltip
+														}
+													}
+													blockoverride "SliceValue" { value = "[PopTypeItem.GetPercentage]" }
+													blockoverride "SliceColor" { color = "[PopTypeItem.GetColor]" }
+													blockoverride "Icon" {
+														texture = "gfx/interface/icons/location_icons/social_class.dds"
+														position = { 0 -2 }
+													}
+													blockoverride "Icon_Size" { size = { 27 27 } }
+													blockoverride "datamodel" { visible = no }
+
+													background = {
+														texture = "gfx/interface/buttons/round_button_alt.dds"
+														texture_density = 2
+														margin = {2 2}
+														margin_bottom = 4
+														modify_texture = {
+															using = color_dark_blue_texture
+															blend_mode = multiply
+														}
+													}
+													background = {
+														texture = "gfx/interface/buttons/round_button_alt.dds"
+														texture_density = 2
+														margin = {2 2}
+														modify_texture = {
+															using = color_gold_texture
+															blend_mode = multiply
+														}
+														modify_texture = {
+															using = color_gold_texture
+															# blend_mode = multiply
+															alpha = 0.3
+														}
+													}
+
+													background = {
+														texture = "gfx/interface/buttons/bg_button.dds"
+														texture_density = 2
+														margin = {1 1}
+														modify_texture = {
+															using = color_bg_blue_texture
+															blend_mode = multiply
+														}
+
+														modify_texture = {
+															using = overlay_paper_03
+														}
+													}
+												}
+
+												icon_pie_left = {
+													blockoverride "PieSize" { size = { 50 50 } }
+													blockoverride "pie_datamodel" {
+														datamodel = "[LocationView.GetProvincePolitics]"
+													}
+													tooltipmeta = {
+														texture = "gfx/interface/icons/location_icons/government.dds"
+													}
+													###Slices and Icon
+													blockoverride "SliceTooltip" {
+														datacontext = "[LocationView.GetLocation]"
+														datacontext = "[Location.GetPopulationChart.GetPopsPiechartWidget]"
+														tooltipwidget = {
+															using = LocationPoliticsTooltip
+														}
+													}
+													blockoverride "SliceValue" { value = "[PopPoliticsItem.GetPercentage]" }
+													blockoverride "SliceColor" { color = "[PopPoliticsItem.GetColor]" }
+													blockoverride "Icon" {
+														texture = "gfx/interface/icons/location_icons/government.dds"
+														position = { 0 -2 }
+													}
+													blockoverride "Icon_Size" { size = { 27 27 } }
+													blockoverride "datamodel" { visible = no }
+
+													using = bg_circle_piechart
+												}
+											}
+										}
+
+										hbox = {
+											layoutpolicy_horizontal = expanding
+											using = bg_number_container_bckg
+											blockoverride "number_container_extra" {
+												margin = {-2 -2}
+												alpha = 0.4
+											}
+											using = bg_frame_squared_brown
+											margin = { 5 5 }
+
+											hbox = {
+												spacing = 5
+												icon = {
+													size = { 28 28 }
+													texture = "gfx/interface/icons/location_icons/demotion.dds"
+													texture_density = 2
+												}
+
+												text_single = {
+													maximumsize = { 30 20 }
+													align = right|nobaseline
+													fontsize = 14
+													text = "[LocationView.GetLocation.GetDemote]"
+												}
+											}
+
+											tooltipwidget = {
+												ContextualTooltipType = {
+													blockoverride "title_icon" {
+														icon = {
+															using = tooltip_title_icon_size
+															texture = "gfx/interface/icons/location_icons/demotion.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.6
+															}
+														}
+													}
+
+
+													blockoverride "title_text" {
+														datacontext = "[LocationView]"
+														text = "DEMOTE_LABEL"
+													}
+													blockoverride "concept_link" {
+														text = "[demotion|E]"
+													}
+
+													blockoverride "tooltip_content" {
+														TooltipStringPairList = {
+															textcontext =  "[LocationView.GetLocation.GetDemoteInfo]"
+														}
+													}
+												}
+											}
+										}
+									}
+
+									blockoverride "demography_datamodel" {
+										datamodel = "[LocationView.GetPops]"
+									}
+
+									blockoverride "demography_item" {
+										hbox = {
+											datacontext = "[LocationPopItem.GetType]"
+											datacontext = "[LocationPopItem.GetLocation]"
+											tooltipwidget = {
+												using = LocationPopItem_Breakdown
+											}
+
+											margin = { 5 0 }
+											spacing = 5
+
+											icon = {
+												layoutpolicy_vertical = expanding
+												size = { 15 -1 }
+												texture = "gfx/interface/component_tiles/bookmark_white.dds"
+												tintcolor = "[LocationPopItem.GetColor]"
+											}
+
+											text_single = {
+												margin_left = 4
+												layoutpolicy_horizontal = expanding
+												size = {-1 12}
+												align = left|nobaseline
+												autoresize = no
+												text = "[LocationPopItem.GetType.GetNameWithNoTooltip]"
+												default_format = "#subtle_name"
+											}
+
+											expand = {}
+
+											widget = {
+												size = {115 12}
+												hbox = {
+													expand = {}
+													spacing = 5
+													text_single = {
+														size = {60 12}
+														autoresize = no
+														align = right|nobaseline
+														text = "[LocationPopItem.GetTotalSize]"
+													}
+
+													text_single = {
+														visible = "[Not(StringIsEmpty(LocationPopItem.GetGrowthForUI))]"
+														maximumsize = {50 12}
+														align = left|nobaseline
+														text = "[LocationPopItem.GetGrowthForUI|Y]"
+													}
+												}
+											}
+
+											text_single = {
+												margin_left = 5
+												visible = "[Between_CFixedPoint(LocationPopItem.GetSize, '(CFixedPoint)0.99', '(CFixedPoint)1.0')]"
+												raw_text = "(>99%)"
+												size = {50 12}
+												autoresize = no
+												align = right|nobaseline
+											}
+
+											text_single = {
+												visible = "[Not(Between_CFixedPoint(LocationPopItem.GetSize, '(CFixedPoint)0.99', '(CFixedPoint)1.0'))]"
+												raw_text = "([LocationPopItem.GetSize|<1%])"
+												size = {50 12}
+												autoresize = no
+												align = right|nobaseline
+												margin_left = 5
+											}
+
+											widget = {
+												size = { 22 22 }
+												using = bg_circle_piechart
+
+												button = {
+													texture_density = 2
+													size = { 70% 70% }
+													parentanchor = center
+
+													datacontext = "[LocationPopItem.GetType]"
+													datacontext = "[LocationPopItem.GetLocation]"
+
+													tooltipwidget = {
+														using = LocationPopItem_Breakdown
+													}
+
+													action_tooltip = {
+														click_type = left
+														click_mode = single
+														title = "OPEN_POP_TYPE_PEOPLE_VIEW"
+														on_action = "[ShowCountryPeopleViewWithPopFilter(PopType.Self, '(bool)yes')]"
+														on_action = "[ShowCountryPeopleViewWithLocation(Location.GetId, '(bool)no')]"
+													}
+
+													texture = "[GetGraphicalCultureTextureForCountryPopType(LocationPopItem.GetType, Location.GetOwner.Self)]"
+
+													glow = {
+														name = "drop_shadow"
+														glow_radius = 3
+														color = {0.0 0.0 0.0 1.0}
+														alpha = 0.3
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+
+							vbox = {
+								minimumsize = { -1 205 }
+								spacing = 5
+
+								layoutpolicy_horizontal = expanding
+								layoutpolicy_vertical = growing
+
+								# culture
+								demography_chart = {
+									using = layoutpolicy_expanding
+
+									blockoverride "piechart_block" {
+										layoutpolicy_vertical = expanding
+										minimumsize = { 90 -1 }
+										margin_top = 3
+										spacing = 3
+
+										hbox = {
+											layoutpolicy_horizontal = expanding
+											margin = { 5 2 }
+											using = bg_number_container_bckg
+											blockoverride "number_container_extra" {
+												margin = {-2 -2}
+												alpha = 0.4
+											}
+											using = bg_frame_squared_brown
+
+											hbox = {
+												spacing = 5
+												icon = {
+													size = { 28 28 }
+													texture = "gfx/interface/icons/location_icons/monthly_assimilation.dds"
+												}
+
+												text_single = {
+													maximumsize = { 30 -1 }
+													align = left|nobaseline
+													fontsize = 14
+													text = "[LocationView.GetLocation.GetAssimilate]"
+												}
+											}
+
+											tooltipwidget = {
+												ContextualTooltipType = {
+													blockoverride "title_icon" {
+														icon = {
+															using = tooltip_title_icon_size
+															texture = "gfx/interface/icons/location_icons/monthly_assimilation.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.6
+															}
+														}
+													}
+
+
+													blockoverride "title_text" {
+														datacontext = "[LocationView]"
+														text = "ASSIMILATE_LABEL"
+													}
+													blockoverride "concept_link" {
+														text = "[assimilation|E]"
+													}
+
+													blockoverride "tooltip_content" {
+														TooltipScrolledStringPairList = {
+															blockoverride "block_scrollarea" { maximumsize = { -1 450 }}
+															textcontext =  "[LocationView.GetLocation.GetAssimilateInfo]"
+														}
+													}
+												}
+											}
+										}
+
+										widget = {
+											using = layoutpolicy_expanding
+											vbox = {
+												using = bg_number_container_bckg
+												blockoverride "number_container_extra" {
+													margin = {-2 -2}
+													alpha = 0.4
+												}
+												using = bg_frame_squared_brown
+												icon_pie_left = {
+													blockoverride "PieSize" { size = { 40 40 } }
+													blockoverride "pie_datamodel" {
+														datamodel = "[LocationView.GetProvinceCultures]"
+													}
+
+													###Slices and Icon
+													blockoverride "SliceTooltip" {
+														datacontext = "[LocationView.GetLocation]"
+														datacontext = "[Location.GetPopulationChart.GetPopsPiechartWidget]"
+														tooltipwidget = {
+															using = LocationPopulationCultureTooltip
+														}
+													}
+													blockoverride "SliceValue" { value = "[PopCultureItem.GetPercentage]" }
+													blockoverride "SliceColor" { color = "[PopCultureItem.GetColor]" }
+													blockoverride "Icon" {
+														texture = "gfx/interface/icons/location_icons/culture.dds"
+														position = { 0 1 }
+													}
+													blockoverride "Icon_Size" {
+														size = { 55% 55% }
+													}
+													blockoverride "datamodel" { visible = no }
+
+													using = bg_circle_piechart
+												}
+											}
+										}
+									}
+
+									blockoverride "demography_datamodel" {
+										datamodel = "[LocationView.GetProvinceCultures]"
+									}
+
+									blockoverride "demography_item" {
+										tooltipwidget = {
+											ContextualTooltipType = {
+												blockoverride "title_icon" {
+													icon = {
+														using = tooltip_title_icon_size
+														texture = "gfx/interface/icons/location_icons/culture.dds"
+
+														glow = {
+															name = "drop_shadow"
+															glow_radius = 3
+															color = {0.0 0.0 0.0 1.0}
+															alpha = 0.3
+														}
+													}
+												}
+												blockoverride "title_text" {
+													text = "POP_CULTURE_OF_ITEM"
+												}
+												blockoverride "concept_link" {
+													text = [culture|E]
+												}
+
+												blockoverride "tooltip_content" {
+													TooltipTableField = {
+														blockoverride "field_background" {
+															background = {
+																using = bg_round_corners
+																alpha = 0.4
+																margin = { -1 0 }
+															}
+														}
+														blockoverride "field_content" {
+															margin = { 10 0 }
+															spacing = 5
+
+															text_single = {
+																icon = {
+																	position = { -22 2 }
+																	texture = "gfx/interface/pie_charts/piechart_legend.dds"
+																	size = { 18 18 }
+																	color = "[PopCultureItem.GetColor]"
+																}
+																autoresize = yes
+																text = "[PopCultureItem.GetName]"
+															}
+
+															text_single = {
+																autoresize = yes
+																text = "[PopCultureItem.GetAbsoluteSize]"
+															}
+
+															text_single = {
+																autoresize = yes
+																text = "[PopCultureItem.GetPercentage|%2]"
+															}
+														}
+													}
+												}
+											}
+										}
+
+										hbox = {
+											margin = { 5 0 }
+											spacing = 3
+											icon = {
+												layoutpolicy_vertical = expanding
+												size = { 15 -1 }
+												texture = "gfx/interface/component_tiles/bookmark_white.dds"
+												tintcolor = "[PopCultureItem.GetColor]"
+											}
+
+											text_single = {
+												layoutpolicy_horizontal = expanding
+												autoresize = no
+												align = left|nobaseline
+												text = "[PopCultureItem.GetName]"
+											}
+
+											text_single = {
+												text = "[PopCultureItem.GetAbsoluteSize]"
+												size = {60 12}
+												autoresize = no
+												align = right|nobaseline
+											}
+
+											text_single = {
+												visible = "[Between_float(PopCultureItem.GetPercentage, '(float)0.99', '(float)1.0')]"
+												raw_text = "(>99%)"
+												size = {50 12}
+												autoresize = no
+												align = right|nobaseline
+												margin_left = 5
+											}
+
+											text_single = {
+												visible = "[Not(Between_float(PopCultureItem.GetPercentage, '(float)0.99', '(float)1.0'))]"
+												raw_text = "([PopCultureItem.GetPercentage|<1%])"
+												size = {50 12}
+												autoresize = no
+												align = right|nobaseline
+												margin_left = 5
+											}
+
+											widget = {
+												size = { 22 22 }
+												using = bg_circle_piechart
+
+												icon = {
+													texture_density = 2
+													size = { 70% 70% }
+													parentanchor = center
+													block "icon_texture" {
+														texture = "gfx/interface/icons/location_icons/population.dds"
+													}
+												}
+											}
+										}
+									}
+								}
+
+								# religion
+								demography_chart = {
+									using = layoutpolicy_expanding
+
+									blockoverride "piechart_block" {
+										layoutpolicy_vertical = expanding
+										minimumsize = { 90 -1 }
+										margin_top = 3
+										spacing = 3
+
+										hbox = {
+											layoutpolicy_horizontal = expanding
+											margin = { 5 2 }
+											using = bg_number_container_bckg
+											blockoverride "number_container_extra" {
+												margin = {-2 -2}
+												alpha = 0.4
+											}
+											using = bg_frame_squared_brown
+
+											hbox = {
+												spacing = 5
+												icon = {
+													size = { 28 28 }
+													texture = "gfx/interface/icons/location_icons/monthly_conversion.dds"
+												}
+
+												text_single = {
+													maximumsize = { 30 -1 }
+													align = left|nobaseline
+													fontsize = 14
+													text = "[LocationView.GetLocation.GetConvert]"
+												}
+											}
+
+											tooltipwidget = {
+												ContextualTooltipType = {
+													blockoverride "title_icon" {
+														icon = {
+															using = tooltip_title_icon_size
+															texture = "gfx/interface/icons/location_icons/monthly_conversion.dds"
+															glow = {
+																name = "drop_shadow"
+																glow_radius = 3
+																color = {0.0 0.0 0.0 1.0}
+																alpha = 0.6
+															}
+														}
+													}
+
+
+													blockoverride "title_text" {
+														datacontext = "[LocationView]"
+														text = "CONVERT_LABEL"
+													}
+													blockoverride "concept_link" {
+														text = "[conversion|E]"
+													}
+
+													blockoverride "tooltip_content" {
+														TooltipStringPairList = {
+															textcontext =  "[LocationView.GetLocation.GetConvertInfo]"
+														}
+													}
+												}
+											}
+										}
+
+										widget = {
+											using = layoutpolicy_expanding
+											vbox = {
+												using = bg_number_container_bckg
+												blockoverride "number_container_extra" {
+													margin = {-2 -2}
+													alpha = 0.4
+												}
+												using = bg_frame_squared_brown
+												icon_pie_left = {
+													blockoverride "PieSize" { size = { 40 40 } }
+													blockoverride "pie_datamodel" {
+														datamodel = "[LocationView.GetProvinceReligions]"
+													}
+
+													###Slices and Icon
+													blockoverride "SliceTooltip" {
+														datacontext = "[LocationView.GetLocation]"
+														datacontext = "[Location.GetPopulationChart.GetPopsPiechartWidget]"
+														tooltipwidget = {
+															using = LocationPopulationReligionTooltip
+														}
+													}
+													blockoverride "SliceValue" { value = "[PopReligionItem.GetPercentage]" }
+													blockoverride "SliceColor" { color = "[PopReligionItem.GetColor]" }
+													blockoverride "Icon" {
+														texture = "gfx/interface/icons/location_icons/main_religion.dds"
+
+													}
+													blockoverride "Icon_Size" {
+														size = { 55% 55% }
+													}
+													blockoverride "datamodel" { visible = no }
+
+													using = bg_circle_piechart
+												}
+											}
+										}
+									}
+
+									blockoverride "demography_datamodel" {
+										datamodel = "[LocationView.GetProvinceReligions]"
+									}
+
+									blockoverride "demography_item" {
+										tooltipwidget = {
+											ContextualTooltipType = {
+												blockoverride "title_icon" {
+													icon = {
+														using = tooltip_title_icon_size
+														texture = "[GetReligionIcon(PopReligionItem.GetReligion.Self)]"
+
+														glow = {
+															name = "drop_shadow"
+															glow_radius = 3
+															color = {0.0 0.0 0.0 1.0}
+															alpha = 0.3
+														}
+													}
+												}
+												blockoverride "title_text" {
+													text = "POP_RELIGION_OF_ITEM"
+												}
+												blockoverride "concept_link" {
+													text = [religion|E]
+												}
+
+												blockoverride "tooltip_content" {
+													TooltipTableField = {
+														blockoverride "field_background" {
+															background = {
+																using = bg_round_corners
+																alpha = 0.4
+																margin = { -1 0 }
+															}
+														}
+														blockoverride "field_content" {
+															margin = { 10 0 }
+															spacing = 5
+
+															text_single = {
+																icon = {
+																	position = { -22 2 }
+																	texture = "gfx/interface/pie_charts/piechart_legend.dds"
+																	size = { 18 18 }
+																	color = "[PopReligionItem.GetColor]"
+																}
+																autoresize = yes
+																text = "[PopReligionItem.GetName]"
+															}
+
+															text_single = {
+																autoresize = yes
+																text = "[PopReligionItem.GetAbsoluteSize]"
+															}
+
+															text_single = {
+																autoresize = yes
+																text = "[PopReligionItem.GetPercentage|%2]"
+															}
+														}
+													}
+												}
+											}
+										}
+
+										hbox = {
+											margin = { 5 0 }
+											spacing = 3
+											icon = {
+												layoutpolicy_vertical = expanding
+												size = { 15 -1 }
+												texture = "gfx/interface/component_tiles/bookmark_white.dds"
+												tintcolor = "[PopReligionItem.GetColor]"
+											}
+
+											text_single = {
+												layoutpolicy_horizontal = expanding
+												autoresize = no
+												align = left|nobaseline
+												text = "[PopReligionItem.GetName]"
+											}
+
+											text_single = {
+												text = "[PopReligionItem.GetAbsoluteSize]"
+												size = {60 12}
+												autoresize = no
+												align = right|nobaseline
+											}
+
+											text_single = {
+												visible = "[Between_float(PopReligionItem.GetPercentage, '(float)0.99', '(float)1.0')]"
+												raw_text = "(>99%)"
+												size = {50 12}
+												autoresize = no
+												align = right|nobaseline
+												margin_left = 5
+											}
+
+											text_single = {
+												visible = "[Not(Between_float(PopReligionItem.GetPercentage, '(float)0.99', '(float)1.0'))]"
+												raw_text = "([PopReligionItem.GetPercentage|1%])"
+												size = {50 12}
+												autoresize = no
+												align = right|nobaseline
+												margin_left = 5
+											}
+
+											widget = {
+												size = { 22 22 }
+												using = bg_circle_piechart
+
+												icon = {
+													texture_density = 2
+													size = { 70% 70% }
+													parentanchor = center
+													block "icon_texture" {
+														texture = "gfx/interface/icons/location_icons/population.dds"
+
+													}
+												}
+											}
+										}
+									}
+								}
+
+								expand = {}
+							}
+						}
+					}
+
+					expand = {}
+				}
+			}
+		}
+	}
+}
+
+select_menu_left = {
+	blockoverride "menu_setup" {
+		name = "location_view_select_province"
+	}
+
+	blockoverride "close_button" {
+		onclick = "[LocationViewSelectProvince.OnClose]"
+	}
+
+	blockoverride "select_content" {
+		select_menu_header = {
+			blockoverride "select_menu_header_extra" {
+				hbox = {
+					layoutpolicy_horizontal = expanding
+					layoutpolicy_vertical = expanding
+					datacontext = "[LocationViewSelectProvince.Parent.GetLocation]"
+					hbox = {
+						layoutpolicy_horizontal = expanding
+						layoutstretchfactor_horizontal = 1
+						subheader_unified_icon = {
+							visible = "[Location.HasOwner]"
+							datacontext = "[Location.GetProvince]"
+							margin = { 0 0 }
+							maximumsize = {165 -1}
+							layoutpolicy_horizontal = expanding
+							tooltipwidget = {
+								using = province_tooltip
+							}
+							blockoverride "subheader_unified_icon_texture" {
+								using = province_texture
+
+								glow = {
+									name = "drop_shadow"
+									glow_radius = 3
+									color = {0.0 0.0 0.0 1.0}
+									alpha = 0.6
+								}
+							}
+							blockoverride "subheader_unified_top_text" {
+								text = "game_concept_province"
+								align = nobaseline
+							}
+							blockoverride "subheader_unified_text_maxsize" { maximumsize = { 125 20 } }
+							blockoverride "subheader_unified_bottom_text" {
+								text = "[Province.GetNameWithNoTooltip]"
+								align = nobaseline
+							}
+							blockoverride "subheader_unified_icon_post"{
+								expand = {}
+							}
+						}
+
+						subheader_unified_icon = {
+							visible = "[Not(Location.HasOwner)]"
+							datacontext = "[Location.GetProvinceDefinition]"
+							margin = { 0 0 }
+							maximumsize = {165 -1}
+							layoutpolicy_horizontal = expanding
+							tooltipwidget = {
+								using = ProvinceDefinition_tooltip
+							}
+							blockoverride "subheader_unified_icon_texture" {
+								using = province_texture
+
+								glow = {
+									name = "drop_shadow"
+									glow_radius = 3
+									color = {0.0 0.0 0.0 1.0}
+									alpha = 0.6
+								}
+							}
+							blockoverride "subheader_unified_text_maxsize" { maximumsize = { 125 20 } }
+							blockoverride "subheader_unified_top_text" {
+								text = "game_concept_province"
+								align = nobaseline
+							}
+							blockoverride "subheader_unified_bottom_text" {
+								text = "[ProvinceDefinition.GetNameWithNoTooltip]"
+								align = nobaseline
+							}
+							blockoverride "subheader_unified_icon_post"{
+								expand = {}
+							}
+						}
+
+						expand = {}
+					}
+
+					# OWNER FLAG
+					widget = {
+						visible = "[Location.HasOwner]"
+						size = { 36 24 }
+
+						country_flag_small = {
+							size = { 100% 100% }
+							datacontext = "[Location.GetOwner]"
+						}
+					}
+
+					hbox = {
+						datacontext = "[Location.GetProvince]"
+						layoutpolicy_horizontal = expanding
+						layoutstretchfactor_horizontal = 1
+						expand = {}
+						subheader_unified_icon = {
+							visible = "[Location.HasOwner]"
+							blockoverride "mirror_layout" {
+								righttoleft = yes
+							}
+							expand = {}
+							margin = { 0 0 }
+							maximumsize = {165 -1}
+							layoutpolicy_horizontal = expanding
+
+							tooltipwidget = {
+								using = province_food_tooltip
+							}
+
+							blockoverride "subheader_unified_icon_texture" {
+								piechart = {
+									size = { 30 30 }
+									using = bg_circle
+									using = bg_circle_piechart
+									using = piechart_angles
+
+									pieslice_no_highlight = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80_green.dds"
+										value = "[FixedPointToFloat(Province.GetFoodCapacityPercent)]"
+										color = { 1 1 1 1 }
+									}
+
+									pieslice_no_highlight = {
+										texture = "gfx/interface/pie_charts/pie_chart_alpha_80_red.dds"
+										value = "[Subtract_float('(float)100.0', FixedPointToFloat(Province.GetFoodCapacityPercent))]"
+										color = { 1 1 1 1 }
+									}
+
+									icon = {
+										size = {  71% 71% }
+										texture = "gfx/interface/icons/unit_view/food.dds"
+										parentanchor = vcenter|hcenter
+
+										modify_texture = {
+											visible = "[Province.IsRiskOfStarving]"
+											using = color_black_texture
+											alpha = 0.5
+											blend_mode = multiply
+										}
+
+										modify_texture = {
+											visible = "[Province.IsRiskOfStarving]"
+											using = color_yellow_texture
+											alpha = 0.6
+										}
+
+										modify_texture = {
+											visible = "[Province.IsStarving]"
+											using = color_black_texture
+											alpha = 0.5
+											blend_mode = multiply
+										}
+
+										modify_texture = {
+											visible = "[Province.IsStarving]"
+											using = color_mid_red_texture
+										}
+									}
+								}
+							}
+							blockoverride "subheader_unified_text_maxsize" { maximumsize = { 125 20 } }
+							blockoverride "subheader_unified_top_text" {
+								text = "game_concept_provincial_food"
+								align = right|nobaseline
+							}
+
+							blockoverride "unified_icon_bottom_content" {
+								spacing = 5
+
+								text_single = { ### STOCKPILE BALANCE
+									raw_text = "[Add_float(FixedPointToFloat(Province.GetFoodFromMarket), FixedPointToFloat(Province.GetMonthlyFood))|+=2]"
+									align = right|nobaseline
+									minimumsize = { -1 20 }
+									maximumsize = { 45 20 }
+									fontsize = 13
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		vbox = {
+			layoutpolicy_horizontal = expanding
+			spacing = 10
+			datacontext = "[LocationViewSelectProvince.Parent.GetLocation.GetProvince]"
+			visible = "[LocationViewSelectProvince.Parent.GetLocation.HasOwner]"
+
+			datamodel = "[Province.GetLocations]"
+			item = {
+				widget = {
+					size = { 511 70 }
+
+					hbox = {
+						using = bg_market_card
+						using = bg_market_card_frame
+
+						location_card = {}
+					}
+				}
+			}
+		}
+
+		vbox = {
+			layoutpolicy_horizontal = expanding
+			spacing = 10
+			datacontext = "[LocationViewSelectProvince.Parent.GetLocation.GetProvinceDefinition]"
+			visible = "[Not(LocationViewSelectProvince.Parent.GetLocation.HasOwner)]"
+
+			datamodel = "[ProvinceDefinition.GetLocations]"
+			item = {
+				widget = {
+					size = { 511 70 }
+
+					hbox = {
+						using = bg_market_card
+						using = bg_market_card_frame
+
+						location_card = {}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces new UI helper values for RGO building levels and removes country-level RGO building visibility controls, consolidating RGO visibility logic to the global scope. Additionally, some unused or redundant code related to profit calculation and visibility toggling has been cleaned up.

**UI Improvements:**
- Added `mnt_location_current_rgo_building_level` and `mnt_location_max_rgo_building_level` scripted values to provide the current and maximum RGO building levels for a location's raw material, enabling better UI display and logic for RGO buttons.

**RGO Visibility Logic Simplification:**
- Removed country-level RGO building visibility controls, including the `mnt_country_hide_building` and `mnt_country_show_building` scripted effects, and their usage in the GUI logic. Now, only global RGO visibility is supported, simplifying the visibility system. [[1]](diffhunk://#diff-68a0bc42f9a23966309b156e4bb7d6edc6907cf78360dd7ab697ce7501d12489L1-L10) [[2]](diffhunk://#diff-68a0bc42f9a23966309b156e4bb7d6edc6907cf78360dd7ab697ce7501d12489L21-L30) [[3]](diffhunk://#diff-0af2605d3ba4835484ac2019b725a68c08e3abab1b719c9241c506b87e6194a5L47-L52) [[4]](diffhunk://#diff-0af2605d3ba4835484ac2019b725a68c08e3abab1b719c9241c506b87e6194a5L66-L77)

**Code Cleanup:**
- Removed an unused section that calculated total profit value added in `calc_location_total_profit_value_added`, as it is no longer needed.
- Fixed file encoding and header comment in `MnT_toggle_rgo_buildings_visibility.txt`.

<img width="733" height="602" alt="image" src="https://github.com/user-attachments/assets/cf000a7b-c3c3-4670-a9fd-214ee4b23d91" />
