### PR TITLE
Block tribal pops from being promoted while filling RGO vacancies

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -35,6 +35,7 @@ Date: 2026-01-20
     - E.g. clay/sand pits, Lumbermills, fruit orchards etc. got merged into the RGO-building
   - Balance changes done with calculation in excel spreadsheet, balance is still a bit rough but should mostly work fine
   - Addapted global RGO size modifiers and RGO ouput modifiers to both affect the maximum amount available of our RGO buildings in Locations
+  - Avoided promoting tribal pops to fill RGO vacancies at the start
 
 #### Bugfixes
 

--- a/main_menu/common/static_modifiers/MnT_RGO_substitution.txt
+++ b/main_menu/common/static_modifiers/MnT_RGO_substitution.txt
@@ -3,4 +3,5 @@
 		category = country
 	}
 	global_pop_promotion_speed = 99999
+	block_tribal_promotion = yes
 }


### PR DESCRIPTION
Right now pop promotion is set to extreme levels to fill building vacancies under the presumption that pops only promote to fill the vacancies present due to RGO building creation.

This is not true; tribal pops will promote. Hence, they are presently eradicated on the first month. This change blocks their promotion.