### PR TITLE
Adjust tribal levies

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -253,6 +253,9 @@ Date: 2026-01-20
 - Land war exhaustion from losses: 100 → 300  
 - Fishing boats’ crew is not peasants, but laborers  
 - Remove effect of dismantle fort peace option on Theodosian walls
+- Tribal levies for non-tribal non-steppe government: 2% → 15%
+- Steppe hordes only make steppe cavalry out of tribesmen and nobles of Turkic and Mongolian cultures
+- Steppe cavalry levies for steppe hordes: 2% → 50%
 
 ##### Situations
 

--- a/in_game/common/levies/MnT_tribal_levies.txt
+++ b/in_game/common/levies/MnT_tribal_levies.txt
@@ -1,0 +1,117 @@
+﻿##########################################################
+# Primarily for Age of Traditions & Age of Renaissance
+##########################################################
+
+
+#scope is POP for triggers
+
+# Picks first valid entry
+
+
+REPLACE:levy_tribal_cavalry= {
+	size = 0.15 #MnT from levy_generic_infantry_size
+
+	allowed_pop_type = tribesmen
+	
+	allow = {
+		location = {
+			market = {
+				OR = {
+					is_produced_in_market = goods:horses 
+					is_traded_in_market = goods:horses 
+				}
+			}
+		}
+	}
+	country_allow = {
+		has_estate_privilege = estate_privilege:tribes_tribal_levies
+		NOT = { government_type = government_type:steppe_horde }
+		NOT = { government_type = government_type:tribe }
+	} 
+
+	unit = a_tribal_cavalry
+}
+
+REPLACE:levy_moa_hunters = {
+	size = 0.15 #MnT from levy_generic_infantry_size
+	
+	allowed_pop_type = peasants
+	allowed_pop_type = tribesmen
+
+	allow = {
+		unit_moa_hunter_pop_trigger = yes
+	}
+	
+	unit = a_moa_hunters
+}
+
+levy_tribesmen = {
+	size = 0.15 #MnT from levy_generic_infantry_size
+	
+	allowed_pop_type = tribesmen
+	
+	unit = a_tribesmen
+}
+
+REPLACE:levy_steppe_horde = {
+	size = 0.5 #MnT from levy_generic_infantry_size
+	
+	#MnT additions to limit pops; the Mongols used the sedentary population as infantry
+	
+	allowed_pop_type = tribesmen
+	allowed_pop_type = nobles
+	
+	# All Turkic and Mongolian cultures, excluding Turkish and Azeri
+	allowed_culture = uyghur_culture
+	allowed_culture = kyrgyz_culture
+	allowed_culture = salar_culture
+	allowed_culture = tuvan_culture
+	allowed_culture = crimean
+	allowed_culture = cuman_culture
+	allowed_culture = kazani
+	allowed_culture = astrakhani
+	allowed_culture = bashkir
+	allowed_culture = mishar
+	allowed_culture = nogai
+	allowed_culture = kumyk_culture
+	allowed_culture = karachay_culture
+	allowed_culture = balkar_culture
+	allowed_culture = chuvash_culture
+	allowed_culture = bolghar_culture
+	allowed_culture = sakha_culture
+	allowed_culture = soyot_culture
+	allowed_culture = khakas_culture
+	allowed_culture = telengit_culture
+	allowed_culture = teleut_culture
+	allowed_culture = chelkans_culture
+	allowed_culture = kumandin_culture
+	allowed_culture = tubalar_culture
+	allowed_culture = shor_culture
+	allowed_culture = yerle_qaliq_culture
+	allowed_culture = turkoman_culture
+	allowed_culture = turkmen_culture
+	allowed_culture = uzbek_culture
+	allowed_culture = khorezmian_culture
+	allowed_culture = qashqai_culture
+	allowed_culture = mongolian_culture
+	allowed_culture = sarta_culture
+	allowed_culture = sibe_culture
+	allowed_culture = bonan_culture
+	allowed_culture = yugur_culture
+	allowed_culture = oirat_culture
+	allowed_culture = daur_culture
+	allowed_culture = buryat_culture
+	allowed_culture = khamag_culture
+	allowed_culture = kharchin_culture
+	allowed_culture = tumed_culture
+	
+
+	country_allow = {
+		OR = {
+			government_type = government_type:steppe_horde
+			government_type = government_type:tribe
+		}
+	}
+	
+	unit = a_steppe_horde
+}


### PR DESCRIPTION
Makes steppe hordes only make steppe cavalry out of tribes and nobles at a 50% participation (every male; yes it is intentionally this high, steppe hordes were very much a use-everyone strategy that would destroy them should they face heavy losses). Also makes tribal levies in non-tribal non-steppe governments at 15% participation, making countries with a lot of tribes have some seriously scary manpower for the early game.