### PR TITLE
Make the tribal estate grow dissatisfied with development

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -58,6 +58,7 @@ Date: 2026-01-20
 - Major vassal swarm nerf, vassals will now require managing and will use their full power to consider their loyalty.
 - Capital Location gives no max control or population capacity anymore.
 - Remove enslavement of all non-state-religion pops from Muslim countries on game startup
+- Tribes estate satisfaction now goes down proportional to average development
 
 ##### Diplomacy
 

--- a/main_menu/common/static_modifiers/MnT_country.txt
+++ b/main_menu/common/static_modifiers/MnT_country.txt
@@ -11,3 +11,7 @@ REPLACE:average_literacy = {
 	skill_of_new_artists = 0.1
 	stability_investment = -0.4 #added by M&T
 }
+
+INJECT:average_development = {
+	tribes_estate_target_satisfaction = -1 # MnT addition so that the tribal estate grows more dissatisfied as you develop
+}


### PR DESCRIPTION
Right now the tribe estate is toothless, when in reality they were a thorn in the side of any state that had to put up with them. This is easy enough to capture, by simply having their satisfaction go down as development goes up.