### PR TITLE
balance(economy): move 25% of Discovery Age Iron boost to 1 age earlier

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -151,7 +151,8 @@ Date: 2026-01-20
 	- base transport cost lowered by 10x for all goods
 	- base travel cost increased by 40x
 	- rivers give 0.5x reduction in trade distance cost
-	- oceans give 0.25x reduction in trade distance cost. 
+	- oceans give 0.25x reduction in trade distance cost.
+- Moved 25% of the Age of Discovery Iron Output boost to Age of Renaissance Gunpowder advance
 	
 ##### Population
 

--- a/in_game/common/advances/MnT_age_of_discovery.txt
+++ b/in_game/common/advances/MnT_age_of_discovery.txt
@@ -22,3 +22,12 @@ REPLACE:matchlock_gun = {
 	# global_fur_output_modifier = 0.1
 	# global_wild_game_output_modifier = 0.1
 }
+
+REPLACE:blast_furnace = {
+	age = age_3_discovery
+	icon = serbian_mining
+	
+	requires = pop_promotion_speed_age_3
+	
+	global_iron_output_modifier = 0.50  #M&T lowered from 75% to 50%. 25% moved to age of renaissance gunpowder advance. 
+}

--- a/in_game/common/advances/MnT_age_of_renaissance.txt
+++ b/in_game/common/advances/MnT_age_of_renaissance.txt
@@ -9,3 +9,7 @@ REPLACE:crown_power_advance_renaissance = {
 	ai_weight = { add = 2 }
 	requires = government_size_renaissance
 }
+
+INJECT:gunpowder_advance = {
+	global_iron_output_modifier = 0.25		#M&T: Split up iron boost from blast_furnace and moved 25% of it here
+}


### PR DESCRIPTION
- Splits the boost from Age of Discovery to have some iron boost in the Age of Renaissance
- Iron/Tool shortage begone (you are not fun)