### PR TITLE
fix(performance): REPLACE vanilla priv that waste performance like crazy

### DIFF
--- a/in_game/common/estate_privileges/MnT_burghers_estate.txt
+++ b/in_game/common/estate_privileges/MnT_burghers_estate.txt
@@ -1,0 +1,29 @@
+﻿### Replace this privilege because the potential is checked for every nation in the game.
+### All nations where checking if any of their alive characters had the is_etienne_marcel variable
+### Massive waste of performance, so move the character check inside allow section.
+
+REPLACE:fra_leadership_of_marcel = {
+	estate = burghers_estate
+
+	potential = {
+		has_or_had_tag = FRA
+	}
+
+	allow = {
+		any_character = {
+			is_alive = yes
+			has_variable = is_etienne_marcel
+		}
+	}
+
+	country_modifier = {
+		global_burghers_estate_power = 0.50
+		parliament_base_support = -0.20
+		global_max_control = -0.03
+		trade_efficiency = small_trade_efficiency_bonus
+		global_trades_per_burgher = 0.10
+	}
+	can_revoke = {
+		always = no
+	}
+}


### PR DESCRIPTION
Vanilla priv was checking in potential every character. So every nation will check every character every time AI checks privs. Massive waste of performance. Move the character check of this privilege from potential to an allow section. 