### PR TITLE
Change modifier for tribal strongholds

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -61,6 +61,7 @@ Date: 2026-01-20
 - Remove enslavement of all non-state-religion pops from Muslim countries on game startup
 - Tribes estate satisfaction now goes down proportional to average development
 - Block tribal governments (tribes and steppe hordes) from settling their tribes.
+- Tribal strongholds privilege now improves rural control instead of making it worse
 
 ##### Diplomacy
 

--- a/in_game/common/estate_privileges/Mnt_tribes_estate.txt
+++ b/in_game/common/estate_privileges/Mnt_tribes_estate.txt
@@ -1,0 +1,13 @@
+REPLACE:local_tribal_strongholds = {
+	estate = tribes_estate
+
+	potential = {
+		capital ?= { region = region:maghreb_region }
+		"estate_power(estate_type:tribes_estate)" > 0
+	}
+	
+	country_modifier = {
+		global_max_rural_control = 0.05 #Mnt from -0.05
+		global_tribes_estate_power = 0.5
+	}
+}


### PR DESCRIPTION
Having this be a penalty to control makes the privilege so awful that the AI will gladly revoke it even if it plunges itself deep into negative stability. Additionally, it cuts against the very description of this privilege.