### PR TITLE
Balance/ai marriage

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -60,8 +60,9 @@ Date: 2026-01-20
 - Capital Location gives no max control or population capacity anymore.
 - Remove enslavement of all non-state-religion pops from Muslim countries on game startup
 - Tribes estate satisfaction now goes down proportional to average development
-- Block tribal governments (tribes and steppe hordes) from settling their tribes.
+- Block tribal governments (tribes and steppe hordes) from settling their tribes
 - Tribal strongholds privilege now improves rural control instead of making it worse
+- AI now has better non-royal marriage logic so that dynasties don't die out nearly as often due to refusal to wed
 
 ##### Diplomacy
 

--- a/in_game/common/character_interactions/MnT_marry_lowborn.txt
+++ b/in_game/common/character_interactions/MnT_marry_lowborn.txt
@@ -50,18 +50,6 @@
 
 	#MnT rewrites entire ai_will_do
 	ai_will_do = {
-	
-		# Don't use this action if you quite literally cannot
-		add = {
-			if = {
-				limit = {
-					scope:recipient ?= {
-						has_available_marriage_slot = no
-					}
-				}
-				value = -1000
-			}
-		}
 		
 		# Don't use this action if your legitimacy is much too low
 		add = {

--- a/in_game/common/character_interactions/MnT_marry_lowborn.txt
+++ b/in_game/common/character_interactions/MnT_marry_lowborn.txt
@@ -68,7 +68,7 @@
 			if = {
 				limit = {
 					scope:actor ?= {
-						legitimacy < 20
+						legitimacy < 40
 					}
 				}
 				value = -1000

--- a/in_game/common/character_interactions/MnT_marry_lowborn.txt
+++ b/in_game/common/character_interactions/MnT_marry_lowborn.txt
@@ -51,8 +51,9 @@
 	#MnT rewrites entire ai_will_do
 	ai_will_do = {
 	
+		# Don't use this action if you quite literally cannot
 		add = {
-			if= {
+			if = {
 				limit = {
 					scope:recipient ?= {
 						has_available_marriage_slot = no
@@ -61,15 +62,25 @@
 				value = -1000
 			}
 		}
+		
+		# Don't use this action if your legitimacy is much too low
+		add = {
+			if = {
+				limit = {
+					scope:actor ?= {
+						legitimacy < 20
+					}
+				}
+				value = -1000
+			}
+		}
+		
 		# Old rulers must get married
 		add = {
 			if = {
 				limit = {
 					scope:recipient = {
 						is_ruler = yes
-					}
-					scope:actor = {
-						legitimacy > 80
 					}
 				}
 				value = scope:recipient.age_in_years

--- a/in_game/common/character_interactions/MnT_marry_lowborn.txt
+++ b/in_game/common/character_interactions/MnT_marry_lowborn.txt
@@ -1,0 +1,163 @@
+﻿REPLACE:marry_lowborn = { 
+
+	sound = UI_action_character_marry_lowborn
+
+	is_consort_action = yes
+	on_own_nation = yes
+	
+	message = yes
+	
+	
+	potential = {
+		scope:actor = {
+			OR = {
+				modifier:care_about_producing_heirs = yes
+				succession_law = heir_selection:signoria_selection
+			}
+		}
+	}
+	
+	ai_tick = daily
+	ai_tick_frequency = 365
+	
+	allow = {
+		scope:actor = {
+			modifier:forbid_marrying_lowborn = no
+		}
+	}
+	
+	select_trigger = {
+		looking_for_a = character
+		source = actor
+		target_flag = recipient
+		name = "choose_character"
+		column = {
+			data = name
+		}
+		visible = {
+			is_alive = yes
+			is_female = no
+		}
+		enabled = {
+			is_eligible_for_royal_marriage = yes
+			modifier:block_marrying_lowborn = no
+			NOT = { has_trait = eunuch }
+			scope:actor.ruler_or_heir_if_regent ?= {
+				is_close_relative = root
+			}
+		}
+	}
+
+	#MnT rewrites entire ai_will_do
+	ai_will_do = {
+	
+		add = {
+			if= {
+				limit = {
+					scope:recipient ?= {
+						has_available_marriage_slot = no
+					}
+				}
+				value = -1000
+			}
+		}
+		# Old rulers must get married
+		add = {
+			if = {
+				limit = {
+					scope:recipient = {
+						is_ruler = yes
+					}
+					scope:actor = {
+						legitimacy > 80
+					}
+				}
+				value = scope:recipient.age_in_years
+				subtract = {
+					value = scope:recipient.modifier:character_life_expectancy
+					multiply = 0.75
+				    # If already married and still no kid but has marriage slots, means we're taking a second wife; be greedy
+					if = {
+						limit = {
+							scope:recipient = {
+								is_married = yes
+								NOT = {
+									any_child = { is_eligible_heir = scope:actor }
+								}
+							}
+						}
+						multiply = 0.9
+					}
+				}
+				multiply = 10
+			}
+		}
+	}
+	
+	effect = {
+		scope:actor = {
+			custom_tooltip = "DEBUTANTE_WILL_MARRY"
+			hidden_effect = {
+				create_character = {
+					religion = scope:recipient.religion
+					age = { 16 21 }
+					female = yes
+					random_estate_type_trigger = {
+						NOR = {
+							this = estate_type:nobles_estate
+							this = estate_type:clergy_estate
+							this = estate_type:dhimmi_estate
+						}
+					}
+					
+					marry_character = scope:recipient 
+				}
+			}
+			if = {
+				limit = {
+					NOR = {
+						has_policy = muslim_marriage
+						has_policy = polygyny
+						has_policy = dishu_system
+						religion = religion:inti
+					}
+				}
+				if = {
+					limit = { 
+						scope:recipient = {
+							has_dynasty = yes
+							OR = {
+								is_ruler = yes
+								is_heir = yes
+							}
+						}
+					}
+					add_legitimacy = legitimacy_mild_penalty
+					add_prestige = prestige_extreme_penalty
+				}
+				else_if = {
+					limit = { 
+						scope:recipient = {
+							has_dynasty = yes
+						}
+					}
+					add_legitimacy = legitimacy_weak_penalty
+					add_prestige = prestige_mild_penalty
+				}
+				else_if = {
+					limit = { 
+						scope:recipient = {
+							has_estate = estate_type:nobles_estate
+						}
+					}
+					add_prestige = prestige_weak_penalty
+				}
+			}
+			else = {
+				add_legitimacy = legitimacy_weak_penalty
+				add_prestige = prestige_weak_penalty
+			}
+		}
+	}
+	
+}	

--- a/in_game/common/character_interactions/MnT_marry_noble.txt
+++ b/in_game/common/character_interactions/MnT_marry_noble.txt
@@ -123,19 +123,7 @@
 
 	#MnT rewrites entire ai_will_do
 	ai_will_do = {
-		# We treat scope:recipient as the important character. This will be evaluated both ways though
-		
-		# Don't use this action if you quite literally cannot
-		add = {
-			if = {
-				limit = {
-					scope:recipient ?= {
-						has_available_marriage_slot = no
-					}
-				}
-				value = -1000
-			}
-		}		
+		# We treat scope:recipient as the important character. This will be evaluated both ways though	
 
 		# Old rulers must get married
 		add = {

--- a/in_game/common/character_interactions/MnT_marry_noble.txt
+++ b/in_game/common/character_interactions/MnT_marry_noble.txt
@@ -1,0 +1,258 @@
+﻿REPLACE:marry_noble = { 
+
+	sound = UI_action_character_marry_noble
+
+	is_consort_action = yes
+	on_own_nation = yes
+	context_menu_click_mode = click # Disable confirm
+	
+	#commenting out the below temporarily in favour of hooking this to the effect scope
+	# sound = "event:/SFX/UI/Character/Unique/sfx_ui_character_arrange_marriage"
+	
+	message = yes
+	
+	
+	potential = {
+		scope:actor = {
+			OR = {
+				government_type = government_type:monarchy
+				succession_law = heir_selection:signoria_selection
+				succession_law = heir_selection:matrilineal_non_exclusive
+			}
+		}
+	}
+	
+	ai_tick = daily
+	ai_tick_frequency = 120
+	
+	allow = {
+	}
+	
+	select_trigger = {
+		looking_for_a = character
+		source = actor
+		target_flag = recipient
+		name = "choose_character"
+		column = {
+			data = name
+		}
+		visible = {
+			is_alive = yes
+		}
+		enabled = {
+			is_eligible_for_royal_marriage = yes
+		}
+	}
+
+	select_trigger = {
+		top_widget = marry_noble_character_top
+		looking_for_a = character
+		source = actor
+		target_flag = target
+		name = "marry_noble_select_title"
+		none_available_msg_key = "marry_noble_no_characters"
+		column = {
+			data = character_info
+		}
+		visible = {
+			OR = {
+				scope:actor = { modifier:can_marry_only_overlord_dynasty_characters = no }
+				AND = {
+					scope:actor = { modifier:can_marry_only_overlord_dynasty_characters = yes }
+					has_dynasty = yes
+					OR = {
+						owner = { any_subject = { this = scope:actor } }
+						dynasty = {
+							any_character_in_dynasty = {
+								owner = { any_subject = { this = scope:actor } }
+							}
+						}
+					}
+				}
+			}
+			OR = {
+				has_estate = estate_type:nobles_estate
+				AND = {
+					scope:actor = { succession_law = heir_selection:signoria_selection }
+					has_estate = estate_type:burghers_estate
+				}
+			}
+			NOT = { is_same_gender = scope:recipient }
+			NOT = { is_close_relative = scope:recipient }
+			character_can_marry_trigger = yes
+			not = { is_spouse_of = scope:recipient }
+			modifier:blocked_from_character_interactions = no
+			character_can_marry_recipient_trigger = yes
+		}
+
+		#enabled = {
+		#	scope:recipient = {
+		#		character_can_marry_recipient_trigger = yes
+		#	}
+		#}
+	}
+	
+	effect = {
+		if = {	
+			limit = {
+				exists = scope:recipient
+				exists = scope:target
+			}
+			scope:recipient = {
+				marry_character = scope:target
+			}
+		}
+		
+		if = {	
+			limit = {
+				scope:actor ?= { NOT = { has_estate_privilege = estate_privilege:noble_marriage_rights } }
+			}
+			scope:actor = {
+				add_legitimacy = legitimacy_mild_penalty
+			}
+		}
+		if = {
+			limit = {
+				scope:recipient = character:vij_bukka_raya_sangama
+			}
+			scope:target = {
+				add_to_list = bukka_raya_previous_spouses
+			}
+		}
+	}
+
+	#MnT rewrites entire ai_will_do
+	ai_will_do = {
+		# We treat scope:recipient as the important character. This will be evaluated both ways though
+		
+		add = {
+			if= {
+				limit = {
+					scope:recipient ?= {
+						has_available_marriage_slot = no
+					}
+				}
+				value = -1000
+			}
+		}		
+
+		# Old rulers must get married
+		add = {
+			if = {
+				limit = {
+					scope:recipient = {
+						is_ruler = yes
+					}
+				}
+				value = scope:recipient.age_in_years
+				subtract = {
+					value = scope:recipient.modifier:character_life_expectancy
+					multiply = 0.66
+				    # If already married and still no kid but has marriage slots, means we're taking a second wife; be greedy
+					if = {
+						limit = {
+							scope:recipient = {
+								is_married = yes
+								NOT = {
+									any_child = { is_eligible_heir = scope:actor }
+								}
+							}
+						}
+						multiply = 0.9
+					}
+				}
+				multiply = 10
+			}
+		}
+		
+		# Old heirs must get married
+		add = {
+			if = {
+				limit = {
+					scope:recipient = {
+						OR = {
+							is_heir = yes
+							AND = {
+								exists = father
+								father = {
+									is_ruler = yes
+								}
+							}
+							AND = {
+								exists = mother
+								mother = {
+									is_ruler = yes
+								}
+							}
+						}
+					}
+				}
+				value = scope:recipient.age_in_years
+				subtract = {
+					value = scope:recipient.modifier:character_life_expectancy
+					multiply = 0.66
+				    # If already married and still no kid but has marriage slots, means we're taking a second wife; be greedy
+					if = {
+						limit = {
+							scope:recipient = {
+								is_married = yes
+								NOT = {
+									any_child = { is_eligible_heir = scope:actor }
+								}
+							}
+						}
+						multiply = 0.9
+					}
+				}
+				multiply = 10
+			}
+		}
+
+		# Do not marry a woman who cannot have a child if you're without eligible heir
+		add = {
+			if = {
+				limit = {
+					scope:target = {
+						is_female = yes
+						age_in_years >= "define:NCharacter|MAX_PREGNANCY_AGE"
+					}
+					scope:recipient = {
+						OR = {
+							is_ruler = yes
+							is_heir = yes
+							AND = {
+								exists = father
+								father = {
+									is_ruler = yes
+								}
+							}
+							AND = {
+								exists = mother
+								mother = {
+									is_ruler = yes
+								}
+							}
+						}
+						NOT = {
+							any_child = { is_eligible_heir = scope:actor }
+						}
+					}
+				}
+				value = -1000
+			}
+		}
+		
+		add = {
+			if = {
+				limit = {
+					scope:target = {
+						is_female = yes
+					}
+				}
+				value = scope:recipient.age_in_years
+				subtract = "define:NCharacter|ADULT_AGE" # Subtract from them every year they're older than the minimum age of marriage
+				multiply = 5
+			}
+		}
+	}
+}	

--- a/in_game/common/character_interactions/MnT_marry_noble.txt
+++ b/in_game/common/character_interactions/MnT_marry_noble.txt
@@ -125,8 +125,9 @@
 	ai_will_do = {
 		# We treat scope:recipient as the important character. This will be evaluated both ways though
 		
+		# Don't use this action if you quite literally cannot
 		add = {
-			if= {
+			if = {
 				limit = {
 					scope:recipient ?= {
 						has_available_marriage_slot = no

--- a/in_game/common/estate_privileges/Mnt_tribes_estate.txt
+++ b/in_game/common/estate_privileges/Mnt_tribes_estate.txt
@@ -1,4 +1,4 @@
-REPLACE:local_tribal_strongholds = {
+﻿REPLACE:local_tribal_strongholds = {
 	estate = tribes_estate
 
 	potential = {


### PR DESCRIPTION
Vanilla AI logic for non-royal marriages left a lot to be desired, including a weird snippet that effectively made the AI never consider lowborn marriages ever. Now the AI weighs marriages against life expectancy, and also accounts for whether or not they can have multiple spouses.