### PR TITLE
Fix building tooltips and diplomatic spending transfer

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -39,6 +39,7 @@ Date: 2026-01-20
 
 #### Bugfixes
 
+- Fix diplomatic spending not transferring gold to nobles estate
 - Stability map mode works
 - Backend error fixes
 

--- a/in_game/common/building_types/MnT_estate_building_maintenance.txt
+++ b/in_game/common/building_types/MnT_estate_building_maintenance.txt
@@ -475,9 +475,6 @@ REPLACE:cathedral = {
 			paper = 0.1
 			copper = 0.05
 			tools = 0.05
-			beeswax = 0.05
-			incense = 0.05
-			wine = 0.05
 			category = building_maintenance
 		}
 	}

--- a/in_game/events/MnT_diplomatic_spending.txt
+++ b/in_game/events/MnT_diplomatic_spending.txt
@@ -18,6 +18,18 @@ diplomatic_spending.1 = {
                 }
             }
         }
+
+        # Add a 1 month delayed display so the tooltip shows accurately to whats being charged.
+        if = { 
+            limit = {
+                has_variable = noble_diplomatic_spending_transfer
+            }
+            set_variable = {
+                name = noble_diplomatic_spending_transfer_tooltip_display
+                value = var:noble_diplomatic_spending_transfer
+            }
+        }
+        
         # For now, 50% of the spending goes to the nobility
         # We can discuss the proportion or whether this should be spread to other estates as well
         set_variable = {
@@ -31,7 +43,7 @@ diplomatic_spending.1 = {
             }
         }
 
-        "root.estate(estate_type:nobles_estate)" = {
+        "estate(estate_type:nobles_estate)" = {
             estate_add_gold = {
                 value = root.var:noble_diplomatic_spending_transfer
             }

--- a/in_game/gui/shared/MnT_government_tooltips.gui
+++ b/in_game/gui/shared/MnT_government_tooltips.gui
@@ -54,13 +54,13 @@
 				}
 
 				TooltipManualTableField = {
-					visible = "[And(Not(Estate.GetType.IsAlwaysLoyal), ObjectsEqual(Player.GetGovernment.GetEstateFromKey('nobles_estate').GetType, Estate.GetType))]"
+					visible = "[And3(Not(Estate.GetType.IsAlwaysLoyal), ObjectsEqual(Player.GetGovernment.GetEstateFromKey('nobles_estate').GetType, Estate.GetType), GreaterThan_CFixedPoint(Estate.GetCountry.MakeScope.GetVariable('noble_diplomatic_spending_transfer_tooltip_display').GetValue, '(CFixedPoint)0'))]"
 					text_single = {
 						text = "ESTATE_DIPLOMATIC_SPENDING_INCOME"
 					}
 					expand = {}
 					text_single = {
-						raw_text = "[Estate.GetCountry.MakeScope.GetVariable('noble_diplomatic_spending_transfer').GetValue|+=2]@gold!"
+						raw_text = "[Estate.GetCountry.MakeScope.GetVariable('noble_diplomatic_spending_transfer_tooltip_display').GetValue|+=2]@gold!"
 					}
 				}
 

--- a/main_menu/gui/shared/MnT_building_tooltips.gui
+++ b/main_menu/gui/shared/MnT_building_tooltips.gui
@@ -208,5 +208,110 @@ template building_tooltip_detail {
 		blockoverride "text" {
 			text = "[Building.GetInputGoodsInformation]"
 		}
+		blockoverride "textblock_background_tint"  {
+			modify_texture = {
+				using = color_red_texture
+			}
+		}
+	}
+
+	TooltipTextBlock = {
+		visible = "[Not(GreaterThan_CFixedPoint(Building.GetLocation.GetMarketAccess,'(CFixedPoint)0'))]"
+		blockoverride "text" {
+			text = "BUILDING_LACK_MARKET_ACCESS"
+		}
+		blockoverride "textblock_background_tint"  {
+			modify_texture = {
+				using = color_red_texture
+			}
+		}
+	}
+
+	TooltipTextBlock = {
+		visible = "[Not(Building.IsOpen)]"
+		blockoverride "text" {
+			text = "[GetToggleBuildingInfo(Building.Self)]"
+		}
+		blockoverride "textblock_background_tint"  {
+			modify_texture = {
+				using = color_red_texture
+			}
+		}
+	}
+
+	TooltipStringPairList = {
+		visible = "[And3(Building.HasLocationModifiers, Building.IsOpen, Not(StringIsEmpty(Building.GetLocationModifiers)))]"
+		textcontext = "[Building.GetLocationModifiers]"
+	}
+	TooltipStringPairList = {
+		visible = "[And3(Building.HasCountryModifiers, Building.IsOpen, Not(StringIsEmpty(Building.GetCountryModifiers)))]"
+		textcontext = "[Building.GetCountryModifiers]"
+	}
+
+	TooltipTextBlock = {
+		visible = "[Building.IsSubsidized]"
+		blockoverride "text" {
+			text = "[Building.GetSubsidizeInfo]"
+		}
+	}
+
+	TooltipTextBlock = {
+		visible = "[Building.ShowHostileInfo]"
+		blockoverride "text" {
+			text = "[Building.GetSubsidizeInfo]"
+		}
+	}
+
+	TooltipListBase = {
+		visible = "[Not(Building.GetType.OnlyEstatesCanBuild)]"
+		TooltipStringPairList = {
+			textcontext = "[Building.GetMarketInfo]"
+		}
+		TooltipListRowContent = {
+			visible = "[Building.IsProducing]"
+			TooltipManualTableField = {
+				blockoverride "field_content" {
+					text_single = {
+						text = "TOTAL_POTENTIAL_PROFIT"
+						default_format = "#color_white"
+					}
+					expand = {}
+					text_single = {
+						raw_text = "[Building.GetProfit|2+=L]@gold!"
+					}
+				}
+			}
+		}
+	}
+
+	TooltipStringPairList = {
+		visible = "[GreaterThan_CFixedPoint(Building.GetProfit, '(CFixedPoint)0')]"
+		textcontext = "BUILDING_TT_PROFIT_PER_LEVEL"
+	}
+
+	TooltipTextBlock = {
+		visible = "[And(LessThan_CFixedPoint(Building.GetProfit, '(CFixedPoint)0'), Not(Building.IsSubsidized))]"
+		blockoverride "text" {
+			text = "BUILDING_PROFIT_TT_TEXT_UNPROFITABLE"
+		}
+
+		blockoverride "textblock_background_tint"  {
+			modify_texture = {
+				using = color_red_texture
+			}
+		}
+	}
+
+	TooltipTextBlock = {
+		visible = "[And(LessThanOrEqualTo_CFixedPoint(Building.GetProfit, '(CFixedPoint)0'), Building.IsSubsidized)]"
+		blockoverride "text" {
+			text = "BUILDING_PROFIT_TT_TEXT_UNPROFITABLE_AND_SUBSIDIZED"
+		}
+
+		blockoverride "textblock_background_tint"  {
+			modify_texture = {
+				using = color_yellow_texture
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Restore building tooltip detail parity and revert cathedral PM to 1.1.10 state
- Fix diplomatic spending not actually transferring gold to nobles estate (estate scope prefix `root.` was blocking execution)
- Add delayed display variable for diplomatic spending tooltip with visibility gating (hide when value is 0)