### PR TITLE
rebalance attrition

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -270,7 +270,6 @@ Date: 2026-01-20
 - Tribal levies for non-tribal non-steppe government: 2% → 15%
 - Steppe hordes only make steppe cavalry out of tribesmen and nobles of Turkic and Mongolian cultures
 - Steppe cavalry levies for steppe hordes: 2% → 50%
-- All climates have a small amount of base attrition, attrition is negated at owned forts.
 
 ##### Situations
 

--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -270,6 +270,7 @@ Date: 2026-01-20
 - Tribal levies for non-tribal non-steppe government: 2% → 15%
 - Steppe hordes only make steppe cavalry out of tribesmen and nobles of Turkic and Mongolian cultures
 - Steppe cavalry levies for steppe hordes: 2% → 50%
+- All climates have a small amount of base attrition, attrition is negated at owned forts.
 
 ##### Situations
 

--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -294,5 +294,5 @@ Date: 2026-01-20
 - Added automated check for correct encodings and line endings via GitHub Actions
 
 ##### Climates
-- replace all climates with the more varied koppen climates
+- replace all climates with the more varied koppen climates 
   - references to older climates point to multiple koppen climates  

--- a/in_game/common/climates/MnT_default.txt
+++ b/in_game/common/climates/MnT_default.txt
@@ -13,7 +13,6 @@ rainforest_climate = {
 		local_food_decay = 0.002
 		local_monthly_food_modifier = 0.15
 		#road_maintenance_cost = 1.5
-		local_army_attrition = 0.25
 		free_capacity_attracts_pops = yes
 	}
 
@@ -37,7 +36,6 @@ monsoon_climate = {
 		local_food_decay = 0.002
 		local_monthly_food_modifier = 0.25
 		#road_maintenance_cost = 1.6
-		local_army_attrition = 0.2
 		free_capacity_attracts_pops = yes
 
 	}
@@ -61,7 +59,6 @@ savanna_winter_climate = {
 		local_life_expectancy = -2
 		local_monthly_food_modifier = 0.1
 		#road_maintenance_cost = 1.3
-		local_army_attrition = 0.1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -84,7 +81,6 @@ savanna_summer_climate = {
 		local_life_expectancy = -2
 		local_monthly_food_modifier = 0.05
 		#road_maintenance_cost = 1.3
-		local_army_attrition = 0.1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -109,7 +105,6 @@ hot_desert_climate = {
 		local_life_expectancy = -4
 		local_supply_limit_modifier = -0.15
 		#road_maintenance_cost = 1.1
-		local_army_attrition = 1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -136,7 +131,6 @@ cold_desert_climate = {
 		local_monthly_food_modifier = -0.45
 		local_supply_limit_modifier = -0.12
 		#road_maintenance_cost = 0.8
-		local_army_attrition = 1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -160,7 +154,6 @@ hot_steppe_climate = {
 		local_life_expectancy = -7
 		local_supply_limit_modifier = -0.08
 		#road_maintenance_cost = 0.9
-		local_army_attrition = 0.5
 		free_capacity_attracts_pops = yes
 	}
 
@@ -187,7 +180,6 @@ cold_steppe_climate = {
 		local_monthly_food_modifier = -0.2
 		local_supply_limit_modifier = -0.05
 		#road_maintenance_cost = 0.6
-		local_army_attrition = 0.5
 		free_capacity_attracts_pops = yes
 	}
 
@@ -212,7 +204,6 @@ mediterranean_climate = {
 		local_life_expectancy = 5
 		local_monthly_food_modifier = 0.1
 		#road_maintenance_cost = 0.65
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -236,7 +227,6 @@ oceanic_mediterranean_climate = {
 		local_life_expectancy = 4
 		local_monthly_food_modifier = 0.05
 		#road_maintenance_cost = 0.5
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -257,7 +247,6 @@ subalpine_mediterranean_climate = {
 		local_population_capacity_modifier = 0.75
 		local_life_expectancy = 1
 		#road_maintenance_cost = 0.4
-		local_army_attrition = 0.2
 		free_capacity_attracts_pops = yes
 	}
 
@@ -281,7 +270,6 @@ monsoon_humid_subtropical_climate = {
 		local_life_expectancy = 2
 		local_food_decay = 0.002
 		local_monthly_food_modifier = 0.15
-		local_army_attrition = 0.05
 		#road_maintenance_cost = 0.75
 		free_capacity_attracts_pops = yes
 	}
@@ -306,7 +294,6 @@ monsoon_oceanic_climate = {
 		local_life_expectancy = 4
 		local_monthly_food_modifier = 0.05
 		#road_maintenance_cost = 0.9
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -329,7 +316,6 @@ monsoon_subpolar_oceanic_climate = {
 		local_life_expectancy = 1
 		local_monthly_food_modifier = -0.05
 		#road_maintenance_cost = 1.1
-		local_army_attrition = 0.1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -352,7 +338,6 @@ humid_subtropical_climate = {
 		local_food_decay = 0.001
 		local_life_expectancy = 2
 		local_monthly_food_modifier = 0.2
-		local_army_attrition = 0.05
 		#road_maintenance_cost = 0.8
 		free_capacity_attracts_pops = yes
 	}
@@ -375,7 +360,6 @@ oceanic_climate = {
 		local_monthly_development_modifier = 0.05
 		local_life_expectancy = 5
 		local_monthly_food_modifier = 0.15
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -399,7 +383,6 @@ subpolar_oceanic_climate = {
 		local_wheat_output_modifier = -0.05
 		local_monthly_food_modifier = -0.05
 		#road_maintenance_cost = 1.5
-		local_army_attrition = 0.1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -422,7 +405,6 @@ mediterranean_continental_climate = {
 		local_life_expectancy = 1
 		local_monthly_food_modifier = 0.1
 		#road_maintenance_cost = 1.5
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -445,7 +427,6 @@ mediterranean_hemiboreal_climate = {
 		local_life_expectancy = 1
 		local_monthly_food_modifier = 0.05
 		#road_maintenance_cost = 1.5
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -471,7 +452,6 @@ mediterranean_boreal_climate = {
 		local_monthly_food_modifier = -0.25
 		local_supply_limit_modifier = -0.1
 		#road_maintenance_cost = 2.2
-		local_army_attrition = 0.4
 		free_capacity_attracts_pops = yes
 	}
 
@@ -497,7 +477,6 @@ mediterranean_hypercontinental_climate = {
 		local_monthly_food_modifier = -0.45
 		local_supply_limit_modifier = -0.15
 		#road_maintenance_cost = 3.2
-		local_army_attrition = 0.85
 		free_capacity_attracts_pops = yes
 	}
 
@@ -519,7 +498,6 @@ monsoon_continental_climate = {
 		local_monthly_development_modifier = 0.05
 		local_monthly_food_modifier = 0.3
 		#road_maintenance_cost = 1.65
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -540,7 +518,6 @@ monsoon_hemiboreal_climate = {
 		local_population_capacity_modifier = 0.55
 		local_monthly_food_modifier = 0.25
 		#road_maintenance_cost = 1.65
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -566,7 +543,6 @@ monsoon_boreal_climate = {
 		local_monthly_food_modifier = -0.20
 		local_supply_limit_modifier = -0.12
 		#road_maintenance_cost = 2.3
-		local_army_attrition = 0.4
 		free_capacity_attracts_pops = yes
 	}
 
@@ -592,7 +568,6 @@ monsoon_hypercontinental_climate = {
 		local_monthly_food_modifier = -0.40
 		local_supply_limit_modifier = -0.18
 		#road_maintenance_cost = 3.3
-		local_army_attrition = 0.8
 		free_capacity_attracts_pops = yes
 	}
 
@@ -614,7 +589,6 @@ continental_climate = {
 		local_monthly_development_modifier = 0.05
 		local_monthly_food_modifier = 0.25
 		#road_maintenance_cost = 1.75
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -635,7 +609,6 @@ hemiboreal_climate = {
 		local_population_capacity_modifier = 0.6
 		local_monthly_food_modifier = 0.2
 		#road_maintenance_cost = 1.75
-		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -661,7 +634,6 @@ boreal_climate = {
 		local_monthly_food_modifier = -0.25
 		local_supply_limit_modifier = -0.1
 		#road_maintenance_cost = 2.5
-		local_army_attrition = 0.35
 		free_capacity_attracts_pops = yes
 	}
 
@@ -687,7 +659,6 @@ hypercontinental_climate = {
 		local_monthly_food_modifier = -0.4
 		local_supply_limit_modifier = -0.15
 		#road_maintenance_cost = 3.5
-		local_army_attrition = 0.75
 		free_capacity_attracts_pops = yes
 	}
 
@@ -714,7 +685,6 @@ andean_tundra_climate = {
 		local_monthly_food_modifier = -0.25
 		local_supply_limit_modifier = -0.1
 		#road_maintenance_cost = 2.5
-		local_army_attrition = 0.3
 		free_capacity_attracts_pops = yes
 	}
 
@@ -740,7 +710,6 @@ tundra_climate = {
 		local_wheat_output_modifier = -0.25
 		local_supply_limit_modifier = -0.15
 		#road_maintenance_cost = 3.2
-		local_army_attrition = 0.85
 		free_capacity_attracts_pops = yes
 	}
 
@@ -767,7 +736,6 @@ polar_climate = {
 		local_monthly_food_modifier = -0.5
 		local_supply_limit_modifier = -0.5
 		#road_maintenance_cost = 10
-		local_army_attrition = 2
 		free_capacity_attracts_pops = yes
 	}
 

--- a/in_game/common/climates/MnT_default.txt
+++ b/in_game/common/climates/MnT_default.txt
@@ -13,7 +13,7 @@ rainforest_climate = {
 		local_food_decay = 0.002
 		local_monthly_food_modifier = 0.15
 		#road_maintenance_cost = 1.5
-		local_army_attrition = 0.5
+		local_army_attrition = 0.25
 		free_capacity_attracts_pops = yes
 	}
 
@@ -37,7 +37,7 @@ monsoon_climate = {
 		local_food_decay = 0.002
 		local_monthly_food_modifier = 0.25
 		#road_maintenance_cost = 1.6
-		local_army_attrition = 0.4
+		local_army_attrition = 0.2
 		free_capacity_attracts_pops = yes
 
 	}
@@ -61,7 +61,7 @@ savanna_winter_climate = {
 		local_life_expectancy = -2
 		local_monthly_food_modifier = 0.1
 		#road_maintenance_cost = 1.3
-		local_army_attrition = 0.2
+		local_army_attrition = 0.1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -84,7 +84,7 @@ savanna_summer_climate = {
 		local_life_expectancy = -2
 		local_monthly_food_modifier = 0.05
 		#road_maintenance_cost = 1.3
-		local_army_attrition = 0.2
+		local_army_attrition = 0.1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -109,7 +109,7 @@ hot_desert_climate = {
 		local_life_expectancy = -4
 		local_supply_limit_modifier = -0.15
 		#road_maintenance_cost = 1.1
-		local_army_attrition = 2
+		local_army_attrition = 1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -136,7 +136,7 @@ cold_desert_climate = {
 		local_monthly_food_modifier = -0.45
 		local_supply_limit_modifier = -0.12
 		#road_maintenance_cost = 0.8
-		local_army_attrition = 2.5
+		local_army_attrition = 1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -160,7 +160,7 @@ hot_steppe_climate = {
 		local_life_expectancy = -7
 		local_supply_limit_modifier = -0.08
 		#road_maintenance_cost = 0.9
-		local_army_attrition = 0.75
+		local_army_attrition = 0.5
 		free_capacity_attracts_pops = yes
 	}
 
@@ -187,7 +187,7 @@ cold_steppe_climate = {
 		local_monthly_food_modifier = -0.2
 		local_supply_limit_modifier = -0.05
 		#road_maintenance_cost = 0.6
-		local_army_attrition = 1
+		local_army_attrition = 0.5
 		free_capacity_attracts_pops = yes
 	}
 
@@ -212,7 +212,7 @@ mediterranean_climate = {
 		local_life_expectancy = 5
 		local_monthly_food_modifier = 0.1
 		#road_maintenance_cost = 0.65
-		local_army_attrition = -0.1
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -236,7 +236,7 @@ oceanic_mediterranean_climate = {
 		local_life_expectancy = 4
 		local_monthly_food_modifier = 0.05
 		#road_maintenance_cost = 0.5
-		local_army_attrition = -0.05
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -257,7 +257,7 @@ subalpine_mediterranean_climate = {
 		local_population_capacity_modifier = 0.75
 		local_life_expectancy = 1
 		#road_maintenance_cost = 0.4
-		local_army_attrition = 0.4
+		local_army_attrition = 0.2
 		free_capacity_attracts_pops = yes
 	}
 
@@ -281,6 +281,7 @@ monsoon_humid_subtropical_climate = {
 		local_life_expectancy = 2
 		local_food_decay = 0.002
 		local_monthly_food_modifier = 0.15
+		local_army_attrition = 0.05
 		#road_maintenance_cost = 0.75
 		free_capacity_attracts_pops = yes
 	}
@@ -305,7 +306,7 @@ monsoon_oceanic_climate = {
 		local_life_expectancy = 4
 		local_monthly_food_modifier = 0.05
 		#road_maintenance_cost = 0.9
-		local_army_attrition = 0.1
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -328,7 +329,7 @@ monsoon_subpolar_oceanic_climate = {
 		local_life_expectancy = 1
 		local_monthly_food_modifier = -0.05
 		#road_maintenance_cost = 1.1
-		local_army_attrition = 0.2
+		local_army_attrition = 0.1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -351,6 +352,7 @@ humid_subtropical_climate = {
 		local_food_decay = 0.001
 		local_life_expectancy = 2
 		local_monthly_food_modifier = 0.2
+		local_army_attrition = 0.05
 		#road_maintenance_cost = 0.8
 		free_capacity_attracts_pops = yes
 	}
@@ -373,7 +375,7 @@ oceanic_climate = {
 		local_monthly_development_modifier = 0.05
 		local_life_expectancy = 5
 		local_monthly_food_modifier = 0.15
-		local_army_attrition = 0.1
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -397,7 +399,7 @@ subpolar_oceanic_climate = {
 		local_wheat_output_modifier = -0.05
 		local_monthly_food_modifier = -0.05
 		#road_maintenance_cost = 1.5
-		local_army_attrition = 0.2
+		local_army_attrition = 0.1
 		free_capacity_attracts_pops = yes
 	}
 
@@ -420,7 +422,7 @@ mediterranean_continental_climate = {
 		local_life_expectancy = 1
 		local_monthly_food_modifier = 0.1
 		#road_maintenance_cost = 1.5
-		local_army_attrition = 0.1
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -443,7 +445,7 @@ mediterranean_hemiboreal_climate = {
 		local_life_expectancy = 1
 		local_monthly_food_modifier = 0.05
 		#road_maintenance_cost = 1.5
-		local_army_attrition = 0.15
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -469,7 +471,7 @@ mediterranean_boreal_climate = {
 		local_monthly_food_modifier = -0.25
 		local_supply_limit_modifier = -0.1
 		#road_maintenance_cost = 2.2
-		local_army_attrition = 0.8
+		local_army_attrition = 0.4
 		free_capacity_attracts_pops = yes
 	}
 
@@ -495,7 +497,7 @@ mediterranean_hypercontinental_climate = {
 		local_monthly_food_modifier = -0.45
 		local_supply_limit_modifier = -0.15
 		#road_maintenance_cost = 3.2
-		local_army_attrition = 1.7
+		local_army_attrition = 0.85
 		free_capacity_attracts_pops = yes
 	}
 
@@ -517,7 +519,7 @@ monsoon_continental_climate = {
 		local_monthly_development_modifier = 0.05
 		local_monthly_food_modifier = 0.3
 		#road_maintenance_cost = 1.65
-		local_army_attrition = 0.1
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -538,7 +540,7 @@ monsoon_hemiboreal_climate = {
 		local_population_capacity_modifier = 0.55
 		local_monthly_food_modifier = 0.25
 		#road_maintenance_cost = 1.65
-		local_army_attrition = 0.15
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -564,7 +566,7 @@ monsoon_boreal_climate = {
 		local_monthly_food_modifier = -0.20
 		local_supply_limit_modifier = -0.12
 		#road_maintenance_cost = 2.3
-		local_army_attrition = 0.8
+		local_army_attrition = 0.4
 		free_capacity_attracts_pops = yes
 	}
 
@@ -590,7 +592,7 @@ monsoon_hypercontinental_climate = {
 		local_monthly_food_modifier = -0.40
 		local_supply_limit_modifier = -0.18
 		#road_maintenance_cost = 3.3
-		local_army_attrition = 1.6
+		local_army_attrition = 0.8
 		free_capacity_attracts_pops = yes
 	}
 
@@ -612,7 +614,7 @@ continental_climate = {
 		local_monthly_development_modifier = 0.05
 		local_monthly_food_modifier = 0.25
 		#road_maintenance_cost = 1.75
-		local_army_attrition = 0.1
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -633,7 +635,7 @@ hemiboreal_climate = {
 		local_population_capacity_modifier = 0.6
 		local_monthly_food_modifier = 0.2
 		#road_maintenance_cost = 1.75
-		local_army_attrition = 0.15
+		local_army_attrition = 0.05
 		free_capacity_attracts_pops = yes
 	}
 
@@ -659,7 +661,7 @@ boreal_climate = {
 		local_monthly_food_modifier = -0.25
 		local_supply_limit_modifier = -0.1
 		#road_maintenance_cost = 2.5
-		local_army_attrition = 0.75
+		local_army_attrition = 0.35
 		free_capacity_attracts_pops = yes
 	}
 
@@ -685,7 +687,7 @@ hypercontinental_climate = {
 		local_monthly_food_modifier = -0.4
 		local_supply_limit_modifier = -0.15
 		#road_maintenance_cost = 3.5
-		local_army_attrition = 1.5
+		local_army_attrition = 0.75
 		free_capacity_attracts_pops = yes
 	}
 
@@ -712,7 +714,7 @@ andean_tundra_climate = {
 		local_monthly_food_modifier = -0.25
 		local_supply_limit_modifier = -0.1
 		#road_maintenance_cost = 2.5
-		local_army_attrition = 0.75
+		local_army_attrition = 0.3
 		free_capacity_attracts_pops = yes
 	}
 
@@ -738,7 +740,7 @@ tundra_climate = {
 		local_wheat_output_modifier = -0.25
 		local_supply_limit_modifier = -0.15
 		#road_maintenance_cost = 3.2
-		local_army_attrition = 1.7
+		local_army_attrition = 0.85
 		free_capacity_attracts_pops = yes
 	}
 
@@ -765,7 +767,7 @@ polar_climate = {
 		local_monthly_food_modifier = -0.5
 		local_supply_limit_modifier = -0.5
 		#road_maintenance_cost = 10
-		local_army_attrition = 5
+		local_army_attrition = 2
 		free_capacity_attracts_pops = yes
 	}
 


### PR DESCRIPTION
Reduces max attrition to make movement not too expensive in the high north morale wise. Adds a tiny bit of attrition in all climates to represent moving armies even without combat is taxing. Standing in ZOC of forts that you own removes attrition.

Edit: had to remove all attrition from all climates, winter still gives attrition. When suffering attrition you don't reinforce, and some tags don't have forts so they'd never be able to reinforce.