### PR TITLE
Prevent nations from rejoining league war on truce

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -6,7 +6,6 @@
   - Urban Rights for industry specialization now completely uncap their associated industry levels rather than giving inherent production bonuses/maluses
   - The Borough Privileges advance, which unlocks generic specialization Urban Rights, has been moved from the Age of Discovery to the Age of Renaissance (banking tree) so it is available earlier
 - Change scaling production efficiency to 1% per additional building level, not modified by current age
-- Reduced AI willingness to join the War of Religions for non-HRE, non-Catholic, and non-Protestant countries, especially Orthodox countries, and added distance from the selected league leader as a negative factor
 
 ### Initial test-release v0.1
 
@@ -538,3 +537,4 @@ Date: 21/05/2026
 ### Balance
 - Increased Levy Cost to a relevant value (75% compared to normal units) compared to vanillas 1%. This is meant to make war actually costly for Feudal nations.
 - Remove local_access_to_raw_materials from raised_levies Location modifier, as cost is now handled by making Levies actually cost upkeep
+- Reduced AI willingness to join the War of Religions for non-HRE, non-Catholic, and non-Protestant countries, especially Orthodox countries, and added distance from the selected league leader as a negative factor. Truces prevent nations from joining again...

--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -6,6 +6,7 @@
   - Urban Rights for industry specialization now completely uncap their associated industry levels rather than giving inherent production bonuses/maluses
   - The Borough Privileges advance, which unlocks generic specialization Urban Rights, has been moved from the Age of Discovery to the Age of Renaissance (banking tree) so it is available earlier
 - Change scaling production efficiency to 1% per additional building level, not modified by current age
+- Reduced AI willingness to join the War of Religions for non-HRE, non-Catholic, and non-Protestant countries, especially Orthodox countries, and added distance from the selected league leader as a negative factor
 
 ### Initial test-release v0.1
 

--- a/in_game/common/generic_actions/MnT_war_of_religions.txt
+++ b/in_game/common/generic_actions/MnT_war_of_religions.txt
@@ -17,6 +17,7 @@
 			religion.group = religion_group:christian
 			at_war = no
 			is_subject = no
+			#M&T changed: Do not allow countries with a truce with either league leader to join the league war.
 			NOT = { has_truce_with = international_organization:protestant_union.leader_country }
 			NOT = { has_truce_with = international_organization:catholic_league.leader_country }
 			NOT = {
@@ -62,6 +63,7 @@
 		none_available_msg_key = "no_valid_religious_faction"
 		column = { data = name }
 		visible = {
+			#M&T changed: Hide league leaders if joining their side would put the actor against a truce partner.
 			OR = {
 				AND = {
 					is_leader_of_international_organization = international_organization:catholic_league
@@ -114,6 +116,7 @@
 		enabled = {
 			scope:actor = {
 				at_war = no
+				#M&T changed: Disable war selection if the opposing league leader has a truce with the actor.
 				trigger_if = {
 					limit = { scope:target = international_organization:catholic_league.leader_country }
 					NOT = { has_truce_with = international_organization:protestant_union.leader_country }
@@ -159,6 +162,7 @@
 				exists = scope:target
 				exists = scope:target_war
 			}
+			#M&T changed: Non-HRE countries are much less interested in joining the HRE league war.
 			if = {
 				limit = {
 					scope:actor = {
@@ -170,6 +174,7 @@
 					value = -75
 				}
 			}
+			#M&T changed: Non-Catholic and non-Protestant countries, especially Orthodox countries, are much less interested.
 			if = {
 				limit = {
 					scope:actor = {
@@ -191,6 +196,7 @@
 					value = -60
 				}
 			}
+			#M&T changed: AI fallback for truce cases that should already be blocked by allow/selection.
 			if = {
 				limit = {
 					scope:actor = {
@@ -208,6 +214,7 @@
 				}
 				add = -10000
 			}
+			#M&T changed: Countries farther from the selected league leader's capital are less interested.
 			add = {
 				desc = "DISTANCE_TO_RELIGIOUS_LEAGUE_LEADER"
 				value = {
@@ -298,6 +305,7 @@
 					}
 				}
 				if = {
+					#M&T changed: Rivalry or threat against the opposing Protestant leader can justify joining the Catholic side.
 					limit = {
 						scope:actor = {
 							OR = {
@@ -312,6 +320,7 @@
 					}
 				}
 				if = {
+					#M&T changed: Being rivaled by the opposing Protestant leader can justify joining the Catholic side.
 					limit = {
 						international_organization:protestant_union.leader_country = {
 							is_rival_of = scope:actor
@@ -351,6 +360,7 @@
 					}
 				}
 				if = {
+					#M&T changed: Rivalry or threat against the opposing Catholic leader can justify joining the Protestant side.
 					limit = {
 						scope:actor = {
 							OR = {
@@ -365,6 +375,7 @@
 					}
 				}
 				if = {
+					#M&T changed: Being rivaled by the opposing Catholic leader can justify joining the Protestant side.
 					limit = {
 						international_organization:catholic_league.leader_country = {
 							is_rival_of = scope:actor

--- a/in_game/common/generic_actions/MnT_war_of_religions.txt
+++ b/in_game/common/generic_actions/MnT_war_of_religions.txt
@@ -1,0 +1,400 @@
+﻿REPLACE:join_the_league_war = {
+	type = situation
+
+	potential = {
+		scope:actor = {
+			NOR = {
+				is_member_of_international_organization = international_organization:catholic_league
+				is_member_of_international_organization = international_organization:protestant_union
+			}
+		}
+	}
+
+	allow = {
+		exists = international_organization:protestant_union.leader_country
+		exists = international_organization:catholic_league.leader_country
+		scope:actor = {
+			religion.group = religion_group:christian
+			at_war = no
+			is_subject = no
+			NOT = { has_truce_with = international_organization:protestant_union.leader_country }
+			NOT = { has_truce_with = international_organization:catholic_league.leader_country }
+			NOT = {
+				any_union_partner = {
+					in_war_of_casus_belli = casus_belli:cb_religious_superiority
+				}
+			}
+		}
+		international_organization:hre = {
+			any_international_organization_member = {
+				in_war_of_casus_belli = casus_belli:cb_religious_superiority
+			}
+		}
+	}
+
+	ai_tick = daily
+	ai_tick_frequency = 180
+
+	#Select our Situation
+	select_trigger = {
+		looking_for_a = situation
+		interaction_source_list = {
+			situation:war_of_religions = {
+				add_to_list = source
+			}
+		}
+		target_flag = recipient
+		name = "choose_situation"
+		column = {
+			data = name
+		}
+		visible = {
+			situation:war_of_religions = this
+			situation_is_active = yes
+		}
+	}
+
+	#Select the Religious League Leader to Aid
+	select_trigger = {
+		looking_for_a = country
+		target_flag = target
+		name = "join_religious_league_choose_faction"
+		none_available_msg_key = "no_valid_religious_faction"
+		column = { data = name }
+		visible = {
+			OR = {
+				AND = {
+					is_leader_of_international_organization = international_organization:catholic_league
+					scope:actor = {
+						NOT = { has_truce_with = international_organization:protestant_union.leader_country }
+					}
+				}
+				AND = {
+					is_leader_of_international_organization = international_organization:protestant_union
+					scope:actor = {
+						NOT = { has_truce_with = international_organization:catholic_league.leader_country }
+					}
+				}
+			}
+		}
+	}
+
+	#Select the Religious League to Aid
+	select_trigger = {
+		looking_for_a = war
+		interaction_source_list = {
+			scope:target = {
+				every_current_war = {
+					limit = {
+						attacker_leader = {
+							OR = {
+								is_leader_of_international_organization = international_organization:catholic_league
+								is_leader_of_international_organization = international_organization:protestant_union
+							}
+						}
+						defender_leader = {
+							OR = {
+								is_leader_of_international_organization = international_organization:catholic_league
+								is_leader_of_international_organization = international_organization:protestant_union
+							}
+						}
+					}
+					add_to_list = source
+				}
+			}
+		}
+		target_flag = target_war
+		name = "join_religious_war_choose_war"
+		none_available_msg_key = "no_valid_religious_war"
+		column = {
+			data = name
+		}
+		visible = {
+		}
+		enabled = {
+			scope:actor = {
+				at_war = no
+				trigger_if = {
+					limit = { scope:target = international_organization:catholic_league.leader_country }
+					NOT = { has_truce_with = international_organization:protestant_union.leader_country }
+				}
+				trigger_if = {
+					limit = { scope:target = international_organization:protestant_union.leader_country }
+					NOT = { has_truce_with = international_organization:catholic_league.leader_country }
+				}
+			}
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				exists = scope:target
+				exists = scope:target_war
+			}
+			scope:actor = {
+				join_war_with = {
+					target = scope:target
+					war = scope:target_war
+					call_in_subjects = yes
+				}
+			}
+		}
+		else = { custom_tooltip = join_the_league_war_effect_tt }
+	}
+
+	ai_will_do = {
+		value = 20
+		
+		#General Value so Spiritualist Countries are more interested in it
+		add = {
+			value = {
+				value = scope:actor.modifier:bias_for_tolerant_policies
+				multiply = -1
+			}
+		}
+		#Religious Alignment Chart
+        if = {
+			limit = { 
+				exists = scope:target
+				exists = scope:target_war
+			}
+			if = {
+				limit = {
+					scope:actor = {
+						NOT = { is_member_of_international_organization = international_organization:hre }
+					}
+				}
+				add = {
+					desc = "NOT_IN_HRE"
+					value = -75
+				}
+			}
+			if = {
+				limit = {
+					scope:actor = {
+						NOR = {
+							is_protestant = yes
+							religion = religion:catholic
+						}
+					}
+				}
+				add = {
+					desc = "NOT_CATHOLIC_OR_PROTESTANT"
+					value = -70
+				}
+			}
+			if = {
+				limit = { scope:actor.religion = religion:orthodox }
+				add = {
+					desc = "ORTHODOX_RELIGIOUS_LEAGUE_DISINTEREST"
+					value = -60
+				}
+			}
+			if = {
+				limit = {
+					scope:actor = {
+						OR = {
+							AND = {
+								scope:target = international_organization:catholic_league.leader_country
+								has_truce_with = international_organization:protestant_union.leader_country
+							}
+							AND = {
+								scope:target = international_organization:protestant_union.leader_country
+								has_truce_with = international_organization:catholic_league.leader_country
+							}
+						}
+					}
+				}
+				add = -10000
+			}
+			add = {
+				desc = "DISTANCE_TO_RELIGIOUS_LEAGUE_LEADER"
+				value = {
+					scope:actor.capital = {
+						value = "distance_to_squared(scope:target.capital)"
+						multiply = -0.00005
+						min = -100
+						max = 0
+					}
+				}
+			}
+			if = {
+				limit = {
+					scope:actor = { is_protestant = yes }
+				}
+				if = {
+					limit = {  scope:target = international_organization:protestant_union.leader_country }
+					add = {
+						desc = "WE_ARE_PROTESTANT"
+						value = 40
+					}
+				}
+				else = {
+					add = {
+						desc = "WE_ARE_CATHOLIC"
+						value = -40
+					}
+				}
+			}
+			else_if = {
+				limit = { scope:actor.religion = religion:catholic }
+				if = {
+					limit = { scope:target = international_organization:catholic_league.leader_country }
+					add = {
+						desc = "WE_ARE_CATHOLIC"
+						value = 40
+					}
+				}
+				else = {
+					add = {
+						desc = "WE_ARE_PROTESTANT"
+						value = -40
+					}
+				}
+			}
+			
+
+			#Opinion Values for Joining Sides
+			add = {
+				desc = "OPINION_OF_RELIGIOUS_LEAGUE_LEADER"
+				value = {
+					scope:target = {
+						scope:actor = {
+							value = this_opinion_of_prev
+							multiply = 0.2
+						}
+					}
+				}
+			}
+
+			if = {
+				limit = { scope:target = international_organization:catholic_league.leader_country }
+				add = {
+					desc = "OPINION_OF_RELIGIOUS_LEAGUE_LEADER"
+					value = {
+						international_organization:protestant_union = {
+							leader_country = {
+								scope:actor = {
+									value = this_opinion_of_prev
+									multiply = -0.4
+								}
+							}
+						}
+					}
+				}
+
+				if = {
+					limit = {
+						scope:actor = {
+							is_allied_with = {
+								target = international_organization:protestant_union.leader_country
+							}
+						}
+					}
+					add = {
+						desc = "ALLIED_TO_RELIGIOUS_LEAGUE_LEADER"
+						value = -100
+					}
+				}
+				if = {
+					limit = {
+						scope:actor = {
+							OR = {
+								is_rival_of = international_organization:protestant_union.leader_country
+								is_a_threat_for_us = international_organization:protestant_union.leader_country
+							}
+						}
+					}
+					add = {
+						desc = "RIVAL_OR_THREAT_TO_RELIGIOUS_LEAGUE_LEADER"
+						value = 100
+					}
+				}
+				if = {
+					limit = {
+						international_organization:protestant_union.leader_country = {
+							is_rival_of = scope:actor
+						}
+					}
+					add = {
+						desc = "RIVALED_BY_RELIGIOUS_LEAGUE_LEADER"
+						value = 50
+					}
+				}
+			}
+			else = {
+				add = {
+					desc = "OPINION_OF_RELIGIOUS_LEAGUE_LEADER"
+					value = {
+						international_organization:catholic_league = {
+							leader_country = {
+								scope:actor = {
+									value = this_opinion_of_prev
+									multiply = -0.4
+								}
+							}
+						}
+					}
+				}
+				if = {
+					limit = {
+						scope:actor = {
+							is_allied_with = {
+								target = international_organization:catholic_league.leader_country
+							}
+						}
+					}
+					add = {
+						desc = "ALLIED_TO_RELIGIOUS_LEAGUE_LEADER"
+						value = -100
+					}
+				}
+				if = {
+					limit = {
+						scope:actor = {
+							OR = {
+								is_rival_of = international_organization:catholic_league.leader_country
+								is_a_threat_for_us = international_organization:catholic_league.leader_country
+							}
+						}
+					}
+					add = {
+						desc = "RIVAL_OR_THREAT_TO_RELIGIOUS_LEAGUE_LEADER"
+						value = 100
+					}
+				}
+				if = {
+					limit = {
+						international_organization:catholic_league.leader_country = {
+							is_rival_of = scope:actor
+						}
+					}
+					add = {
+						desc = "RIVALED_BY_RELIGIOUS_LEAGUE_LEADER"
+						value = 50
+					}
+				}
+			}
+        
+			# Makes it so AI Juniors in a Union will never block the player from joining 
+			scope:actor = {
+				if = {
+					limit = {
+						is_member_of_international_organization_of_type = {
+							type = union
+						}
+						NOT = {
+							union = {
+								country_is_senior_partner = {
+									country = scope:actor
+								}
+							}
+						}
+					}
+					add = -10000
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Prevent nations from rejoining league war when having a truce with one of the war leaders. Additionally tweaked AI weights in order to get more sensible results and not global war.