### PR TITLE
Amenities and farming village tweaks

### DIFF
--- a/.metadata/metadata.json
+++ b/.metadata/metadata.json
@@ -1,7 +1,7 @@
 ﻿{
   "name" : "MEIOU and Taxes",
   "id" : "meiou_and_taxes",
-  "version" : "0.2.5",
+  "version" : "0.2.6",
   "game_id" : "eu5",
   "supported_game_version" : "1.3.*",
   "short_description" : "Overhaul in the works",

--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -552,7 +552,7 @@ Date: 21/05/2026
 ##### M&T v0.2.6
 
 ### Balance
-- Up Amenities required for City (4 -> 5) and Megalopolis (8 -> 10)
+- Up Amenities required for City (4 -> 5) and Megalopolis (8 -> 11)
 - Set important_for_AI flag to Amenities building_type
 - Require 20k Burghers for a Location to be valid to become a Megalopolis (in addition to total pop being 200k)
 

--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -548,3 +548,14 @@ Date: 21/05/2026
 
 ### Misc changes
 - Remove modcon loading screen again
+
+##### M&T v0.2.6
+
+### Balance
+- Up Amenities required for City (4 -> 5) and Megalopolis (8 -> 10)
+- Set important_for_AI flag to Amenities building_type
+- Require 20k Burghers for a Location to be valid to become a Megalopolis (in addition to total pop being 200k)
+
+# Mechanics
+- Don't let nations and estates build farming villages
+  - There is a scripted system that handles that and should be the only thing handling it

--- a/in_game/common/building_types/rural_buildings.txt
+++ b/in_game/common/building_types/rural_buildings.txt
@@ -125,7 +125,9 @@ farming_village = {
 	
 	category = village_category
 	employment_size = 1
-	
+
+	forbidden_for_estates = yes
+
 	rural_settlement = yes
 	
 	price = build_price_farming_village
@@ -137,7 +139,11 @@ farming_village = {
 			arctic_climate_trigger = yes
 		}
 	}
-	
+
+	country_potential = {
+		always = no
+	}
+
 	can_destroy = {
 		scope:building.owner = { is_ai = no }
 	}

--- a/in_game/common/building_types/town_buildings.txt
+++ b/in_game/common/building_types/town_buildings.txt
@@ -743,7 +743,8 @@ urban_amenities = {
 	megalopolis = yes
 
 	forbidden_for_estates = yes
-
+	important_for_ai = yes
+	
 	price = expand_rgo_farming 
 	increase_per_level_cost = 3
 	

--- a/in_game/common/location_ranks/MnT_default.txt
+++ b/in_game/common/location_ranks/MnT_default.txt
@@ -59,7 +59,7 @@ REPLACE:megalopolis = {
 		#owner ?= { is_subject = no }   #M&T removed as arbitrary limitations
 		location_building_level = {
 			building_type = building_type:urban_amenities
-			value >= 10
+			value >= 11
 		}
 	}
 	max_rank = yes

--- a/in_game/common/location_ranks/MnT_default.txt
+++ b/in_game/common/location_ranks/MnT_default.txt
@@ -58,7 +58,7 @@ REPLACE:megalopolis = {
 		#owner ?= { is_subject = no }   #M&T removed as arbitrary limitations
 		location_building_level = {
 			building_type = building_type:urban_amenities
-			value >= 8
+			value >= 10
 		}
 	}
 	max_rank = yes
@@ -124,7 +124,7 @@ REPLACE:city = {
 		modifier:cannot_upgrade_location = no
 		location_building_level = {
 			building_type = building_type:urban_amenities
-			value >= 4
+			value >= 5
 		}
 		#urban_amenities >= 5
 	}

--- a/in_game/common/location_ranks/MnT_default.txt
+++ b/in_game/common/location_ranks/MnT_default.txt
@@ -52,6 +52,7 @@ REPLACE:megalopolis = {
 	allow = {
 		location_rank = location_rank:city
 		population >= 200.000			# M&T changed from 400k
+		num_pop_type:burghers >= 20		# M&T added, at least 20k Burghers
 		modifier:cannot_upgrade_location = no
 		#is_market_center = yes			#M&T removed as arbitrary limitations
 		#is_capital = yes				#M&T removed as arbitrary limitations

--- a/loading_screen/gui/custom_loading_screen.gui
+++ b/loading_screen/gui/custom_loading_screen.gui
@@ -619,7 +619,7 @@ template custom_version_label {
 				fontsize = 12
 				font = Debug
 				minimumsize = { -1 25 }
-				raw_text = "0.2.5"		#version number here
+				raw_text = "0.2.6"		#version number here
 			}
 		}
 

--- a/loading_screen/gui/loading_screen.gui
+++ b/loading_screen/gui/loading_screen.gui
@@ -96,7 +96,7 @@ template version_label {
 				fontsize = 12
 				font = Debug
 				minimumsize = { -1 25 }
-				raw_text = "0.2.5"		#version number here
+				raw_text = "0.2.6"		#version number here
 			}
 		}
 


### PR DESCRIPTION
- Up Amenities required for City (4 -> 5) and Megalopolis (8 -> 10)
- Set important_for_AI flag to Amenities building_type
- Require 20k Burghers for a Location to be valid to become a Megalopolis (in addition to total pop being 200k)
- Don't let nations and estates build farming villages
  - There is a scripted system that handles that and should be the only thing handling it
 - Set version number as displayed to 0.2.6 as 0.2.5 has already been released