### PR TITLE
Lower cost of levied armies

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -555,6 +555,10 @@ Date: 21/05/2026
 - Up Amenities required for City (4 -> 5) and Megalopolis (8 -> 11)
 - Set important_for_AI flag to Amenities building_type
 - Require 20k Burghers for a Location to be valid to become a Megalopolis (in addition to total pop being 200k)
+- Make Levies cost only 35% of 'real' cost instead of 75%
+  - Was bankrupting too many AIs
+  - AI too dumb to not fully mobilize
+  - Reduce Tribal Levy cost even more as their goods demand for horses was very harsh on the Tribal nations with poor eco's
 
 # Mechanics
 - Don't let nations and estates build farming villages

--- a/in_game/common/goods_demand/army_demands.txt
+++ b/in_game/common/goods_demand/army_demands.txt
@@ -204,10 +204,10 @@ pikemen_maintenance = {
 	category = regiment_maintenance
 }
 
-steppe_horse_archers_maintenance  = {
-	leather = 0.02
-	horses = 0.4
-	weaponry = 0.02
+steppe_horse_archers_maintenance  = {		#M&T reduced values because we made levies cost maintenance. These tribal cav where too expensive for Tribal Nations
+	leather = 0.01
+	horses = 0.1
+	weaponry = 0.01
 	category = regiment_construction
 }
 rifle_infantry_maintenance = {

--- a/loading_screen/common/defines/MnT_Defines.txt
+++ b/loading_screen/common/defines/MnT_Defines.txt
@@ -13,7 +13,7 @@ NCountry = {
 
 NUnit = {
 	ARMY_MOVEMENT_SPEED = 0.10 #M&T from 0.13
-	LEVY_MAINTENANCE_FACTOR = 0.75 #M&T from 0.01 # Percentage of costs levies actually have to pay for their upkeep. Increased in order to make levies actually cost money...
+	LEVY_MAINTENANCE_FACTOR = 0.35 #M&T from 0.01 # Percentage of costs levies actually have to pay for their upkeep. Increased in order to make levies actually cost money...
 }
 
 NAI = {


### PR DESCRIPTION
It was too much

Lower base value 75% -> 35%

Lower goods cost for tribal levies as they were especially expensive, and generally raised by poor states 

AI too dumb to understand to partially mobilize. So although not a nice change to have to make, the AI just cannot at this moment handle the cost of raising all levies, which every AI is doing rn every war. 