### PR TITLE
Temp fix to ensure player can still build farming villages after blocking AI.

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -9,7 +9,7 @@
 
 ### Initial test-release v0.1
 
-Date: 21/05/2026
+Date: 21/05/2026 
 
 #### Features
 

--- a/in_game/common/building_types/rural_buildings.txt
+++ b/in_game/common/building_types/rural_buildings.txt
@@ -151,7 +151,7 @@ farming_village = {
 	}
 
 	country_potential = {
-		always = no
+		is_ai = no
 	}
 
 	can_destroy = {

--- a/in_game/events/MnT_food.txt
+++ b/in_game/events/MnT_food.txt
@@ -83,7 +83,10 @@ mnt_food.2 = {
 		}
 		else = {
 			every_market_present_in_country = {
-				limit  = { market_monthly_food_balance < 0 }
+				limit  = { 
+					market_monthly_food_balance < 0
+					market_food_percentage < 80
+				}
 				random_location_in_market = {
 					limit  = { 
 						owner ?= root


### PR DESCRIPTION
Just as it says. The fix to prevent the AI spamming farming villages prevented players from building them. Player nations have no method of gaining farming villages at all unless able to build them, thus need to be able to build them.