### PR TITLE
Fix army movement speed being silently overridden, and plague spread in roadless locations

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -608,3 +608,4 @@ Date: 21/05/2026
 - Fix Great Pestilence Situation being visible to Old World nations when they get one of the three diseases during the Situation
 - Fix errors on startup that about too many farming villages in Locations
 - Fix army movement speed being overridden by the Faster Universalis defines
+- Fix plague spread threshold being reduced in locations without roads

--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -607,3 +607,4 @@ Date: 21/05/2026
 - Fixed typo making Subtropical Highland Climate -50% dev growth instead of intended -5% dev growth.
 - Fix Great Pestilence Situation being visible to Old World nations when they get one of the three diseases during the Situation
 - Fix errors on startup that about too many farming villages in Locations
+- Fix army movement speed being overridden by the Faster Universalis defines

--- a/in_game/common/diseases/MnT_bubonic_plague.txt
+++ b/in_game/common/diseases/MnT_bubonic_plague.txt
@@ -396,7 +396,7 @@
 		}#If there is a road reduce it
 		else_if = {
 			limit = {
-				num_roads >= 0
+				num_roads >= 1
 			}
 			multiply = 0.50
 		}

--- a/loading_screen/common/defines/MnT_Defines.txt
+++ b/loading_screen/common/defines/MnT_Defines.txt
@@ -12,7 +12,11 @@ NCountry = {
 }
 
 NUnit = {
-	ARMY_MOVEMENT_SPEED = 0.10 #M&T from 0.13
+	# Tick-rescale trap: fum_adjustable_defines.txt sets HOUR_TICK = 24 (1 tick/day) where
+	# vanilla has 2 (12/day), so every per-tick speed in this mod is on a x12 axis - vanilla's
+	# 0.13 reads as 1.56 there. 1.2 is M&T's intended 0.10 x12. This must stay the only file
+	# setting it: fum_ sorts after MnT_ in ASCII load order and silently won, killing the 0.10.
+	ARMY_MOVEMENT_SPEED = 1.2 #M&T from 0.13 (1.56 on the x12 axis)
 	LEVY_MAINTENANCE_FACTOR = 0.35 #M&T from 0.01 # Percentage of costs levies actually have to pay for their upkeep. Increased in order to make levies actually cost money...
 }
 

--- a/loading_screen/common/defines/fum_adjustable_defines.txt
+++ b/loading_screen/common/defines/fum_adjustable_defines.txt
@@ -55,7 +55,8 @@
 
 # 12x the vanilla per-tick speeds to match vanilla distance per in-game day.
 NUnit = {
-	ARMY_MOVEMENT_SPEED = 1.56 # 0.13
+	# ARMY_MOVEMENT_SPEED lives in MnT_Defines.txt (1.2 = M&T's own 0.10 on this x12 axis).
+	# Do not re-add it here: fum_ sorts last in ASCII load order and would silently win again.
 	NAVY_MOVEMENT_SPEED = 6.0 # 0.5
 }
 


### PR DESCRIPTION
Two independent one-line fixes, both cases where a condition was true everywhere it was tested.

## Army movement speed

`NUnit.ARMY_MOVEMENT_SPEED` is set in **two** files under `loading_screen/common/defines/`:

| File | Value |
|---|---|
| `MnT_Defines.txt` | `0.10` |
| `fum_adjustable_defines.txt` | `1.56` |

The engine resolves a contested define by filename order and reports it nowhere. `fum_` sorts after `MnT_` in ASCII, so `1.56` won and M&T's `0.10` had no effect.

The values aren't directly comparable, because `fum_adjustable_defines.txt` also sets `HOUR_TICK = 24` (one tick per day) where vanilla has `2` (twelve per day). Every per-tick speed in this mod is therefore on a x12 axis, and the FUM file's own header says so: vanilla's `0.13` becomes `1.56`. M&T's intended `0.10` is `1.2` on that same axis.

**Fix:** set `1.2` in `MnT_Defines.txt`, and stop `fum_adjustable_defines.txt` setting the key at all, leaving a comment in each file pointing at the other. `NAVY_MOVEMENT_SPEED` is untouched — it is only set in one place.

**Effect:** armies march at 10/13ths of vanilla daily distance, which is the `0.13 -> 0.10` slowdown M&T intended. No colliding key is left between the two files.

## Plague spread threshold

In `location_infection_spread_threshold` (`MnT_bubonic_plague.txt`), an `else_if` tested:

```
num_roads >= 0
```

which is true of every location, roads or not. The comment immediately above it — `#If there is a road reduce it` — gives the intended condition. This came in with the base-game file the block was copied from.

**Fix:** `num_roads >= 1`.

**Effect:** roadless locations outside the difficult-terrain branch keep the 30% neighbour-seeding threshold instead of having it halved to 15%. Locations with roads are unaffected.

## Notes

- Both changes are additionally commented in place, so the next reader sees why the value is what it is rather than rediscovering the load-order trap.
- Changelog entry added under a new `##### M&T v0.2.91` heading. Happy to move it under `v0.2.9` or drop the heading if you'd rather own the version number.