### PR TITLE
Balance: reduce levy upkeep cost

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -604,6 +604,8 @@ Date: 21/05/2026
 - Development now directly reduced by looting and sieges.
 - Development will now decay at low enough prosperity levels.
 - Promotion rules changed, peasants unable to promote to nobles, many other classes able to promote 'upward'.
+- Reduce global upkeep cost of Levies from 35% to 20%
+- Reduce Tribal Levies goods upkeep cost on top of that
 
 ##### Population
 - Entire max population system reworked to be more climate related, and lower in general.

--- a/in_game/common/goods_demand/army_demands.txt
+++ b/in_game/common/goods_demand/army_demands.txt
@@ -206,9 +206,9 @@ pikemen_maintenance = {
 
 steppe_horse_archers_maintenance  = {		#M&T reduced values because we made levies cost maintenance. These tribal cav where too expensive for Tribal Nations
 	leather = 0.01
-	horses = 0.1
+	horses = 0.01
 	weaponry = 0.01
-	category = regiment_construction
+	category = regiment_maintenance
 }
 rifle_infantry_maintenance = {
 	firearms = 0.60 # 6x more expensive than muskets
@@ -220,9 +220,9 @@ rifle_infantry_maintenance = {
 
 steppe_horse_auxiliary_maintenance = {
 	leather = 0.02
-	horses = 1.0
+	horses = 0.1
 	salt = 0.02
-	category = regiment_construction
+	category = regiment_maintenance
 }
 
 cavalry_maintenance  = {
@@ -295,8 +295,8 @@ elephant_infantry_maintenance = {
 
 
 a_tribesmen_maintenance = {
-	weaponry = 0.1
-	category = regiment_construction
+	weaponry = 0.01
+	category = regiment_maintenance
 }
 a_warriors_maintenance = {
 	weaponry = 0.1

--- a/loading_screen/common/defines/MnT_Defines.txt
+++ b/loading_screen/common/defines/MnT_Defines.txt
@@ -13,7 +13,7 @@ NCountry = {
 
 NUnit = {
 	ARMY_MOVEMENT_SPEED = 1.2 #M&T from 0.13 # 12x the vanilla per-tick speeds to match vanilla distance per in-game day.
-	LEVY_MAINTENANCE_FACTOR = 0.35 #M&T from 0.01 # Percentage of costs levies actually have to pay for their upkeep. Increased in order to make levies actually cost money...
+	LEVY_MAINTENANCE_FACTOR = 0.2 #M&T from 0.01 # Percentage of costs levies actually have to pay for their upkeep. Increased in order to make levies actually cost money...
 }
 
 NAI = {


### PR DESCRIPTION
- Reduce global upkeep cost of Levies from 35% to 20%
- Reduce Tribal Levies goods upkeep cost on top of that
- Also make sure Tribal Levy upkeep costs are displayed as upkeep and not construction