### PR TITLE
Fix colonial integration

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -616,4 +616,4 @@ Date: 21/05/2026
 - Fix errors on startup that about too many farming villages in Locations
 - Fixed morale loss to scale with removal of hours
 - Fixed duplicated movement speed in defines, correcting movement speed to M&T values.
- 
+- Fixed colonized locations not integrating automatically.

--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -611,9 +611,9 @@ Date: 21/05/2026
 - Paradox rescaled population promotion speed, causing our own scaling to be too aggressive. 
 
 ### Fixes
-- Fixed typo making Subtropical Highland Climate -50% dev growth instead of intended -5% dev growth.
-- Fix Great Pestilence Situation being visible to Old World nations when they get one of the three diseases during the Situation
-- Fix errors on startup that about too many farming villages in Locations
-- Fixed morale loss to scale with removal of hours
+- Fixed a typo which had made the 'Subtropical Highland' climate give -50% dev growth instead of the intended -5% dev growth.
+- Fixed the 'Great Pestilence' situation being visible to 'Old World' nations when they had gotten one of the three diseases during the situation.
+- Fixed errors on startup which had caused too many farming villages in locations.
+- Fixed morale loss, which failed to scale with the removal of hours.
 - Fixed duplicated movement speed in defines, correcting movement speed to M&T values.
 - Fixed colonized locations not integrating automatically.

--- a/in_game/common/on_action/aut_on_actions.txt
+++ b/in_game/common/on_action/aut_on_actions.txt
@@ -1,4 +1,4 @@
-﻿@aut_version = 100 # Must match aut_effects.txt
+﻿@aut_version = 101 # Must match aut_effects.txt
 
 ### Bootstrap
 

--- a/in_game/common/on_action/aut_on_actions.txt
+++ b/in_game/common/on_action/aut_on_actions.txt
@@ -40,7 +40,9 @@ aut_init_check = {
 # Only acts on locations that enter conquered status.
 
 aut_on_location_conquered = {
-	trigger = { integration_level = conquered }
+	trigger = { 
+		MnT_location_needs_integration_trigger = yes
+	 }
 
 	effect = {
 		aut_track_location = yes
@@ -64,9 +66,7 @@ aut_monthly_update = {
 
 			if = {
 				limit = {
-					NOT = {
-						integration_level = conquered
-					}
+					MnT_location_needs_integration_trigger = no
 				}
 				add_to_local_variable_list = { name = aut_remove_queue target = this }
 			}

--- a/in_game/common/scripted_effects/aut_effects.txt
+++ b/in_game/common/scripted_effects/aut_effects.txt
@@ -19,7 +19,7 @@ aut_apply_integration_script = {
 							is_ownable = yes
 							has_owner = yes
 							owner ?= scope:owner_scope
-							NOT = { integration_level = conquered }
+							MnT_location_needs_integration_trigger = no
 						}
 						AND = {
 							is_port = yes
@@ -27,7 +27,7 @@ aut_apply_integration_script = {
 								is_ownable = yes
 								has_owner = yes
 								owner ?= scope:owner_scope
-								NOT = { integration_level = conquered }
+								MnT_location_needs_integration_trigger = no
 							}
 						}
 					}
@@ -238,7 +238,7 @@ aut_initialize = {
 
 	every_country = {
 		every_owned_location = {
-			limit = { integration_level = conquered }
+			limit = { MnT_location_needs_integration_trigger = yes }
 			aut_track_location = yes
 			aut_apply_integration_script = yes
 		}

--- a/in_game/common/scripted_effects/aut_effects.txt
+++ b/in_game/common/scripted_effects/aut_effects.txt
@@ -1,4 +1,4 @@
-﻿@aut_version = 100 # 1.0.0
+﻿@aut_version = 101 # 1.0.1
 
 aut_apply_integration_script = {
 	owner = {

--- a/in_game/common/scripted_triggers/MnT_location_triggers.txt
+++ b/in_game/common/scripted_triggers/MnT_location_triggers.txt
@@ -31,3 +31,10 @@ REPLACE:town_illustration_trigger = {
 		location_rank ?= location_rank:megalopolis
 	}
 }
+
+MnT_location_needs_integration_trigger = {
+	OR = {
+		integration_level = conquered
+		integration_level = colonized
+	}
+}


### PR DESCRIPTION
Colonial locations have not been integrating. Reason beeing: Only the integration status "conquered" made a location be regarded as "to be integrated".

Now, a scripted_trigger has been added that checks against the status "conquered" and "colonized" and is reused where needed, so should these requirements change ever again, there is _one_ code point to edit.