### PR TITLE
feat(buildings): tag goods-output buildings as infrastructure

### DIFF
--- a/Documentation/Change log.md
+++ b/Documentation/Change log.md
@@ -6,6 +6,7 @@
   - Urban Rights for industry specialization now completely uncap their associated industry levels rather than giving inherent production bonuses/maluses
   - The Borough Privileges advance, which unlocks generic specialization Urban Rights, has been moved from the Age of Discovery to the Age of Renaissance (banking tree) so it is available earlier
 - Change scaling production efficiency to 1% per additional building level, not modified by current age
+- Buildings that only boost the output of goods in their location, without producing anything themselves, are now Infrastructure buildings: mercury patios, smelters, windmills, sawmills and the special buildings doing the same. They are no longer left unstaffed by employment systems that staff the most profitable buildings first, and they moved out of other building categories, which also affects the categories' triggers.
 
 ### Initial test-release v0.1
 

--- a/in_game/common/building_types/MnT_building_category_changes.txt
+++ b/in_game/common/building_types/MnT_building_category_changes.txt
@@ -1,0 +1,28 @@
+﻿# Buildings that only raise the output of goods in their location, and produce nothing
+# themselves, belong to the infrastructure category. Employment systems that staff the
+# most profitable buildings first otherwise leave their vacancies unfilled, and they are
+# not production buildings in the location window either.
+
+INJECT:bubu_building = {
+	category = infrastructure_category
+}
+
+INJECT:great_valley_complex = {
+	category = infrastructure_category
+}
+
+INJECT:llotja_seda = {
+	category = infrastructure_category
+}
+
+INJECT:pomor_outpost = {
+	category = infrastructure_category
+}
+
+INJECT:schwaz_mine = {
+	category = infrastructure_category
+}
+
+INJECT:trade_company_local_venture = {
+	category = infrastructure_category
+}

--- a/in_game/common/building_types/common_buildings.txt
+++ b/in_game/common/building_types/common_buildings.txt
@@ -162,7 +162,7 @@ mercury_patio = {
 	pop_type = laborers
 
 	important_for_ai = yes
-	category = rgo_building_category
+	category = infrastructure_category
 	employment_size = advanced_peasant_building_employment
 	
 	rural_settlement = yes

--- a/in_game/common/building_types/rural_buildings.txt
+++ b/in_game/common/building_types/rural_buildings.txt
@@ -540,7 +540,7 @@ windmill = {
 	employment_size = rural_peasant_enhance_employment
 	
 	
-	category = rgo_building_category
+	category = infrastructure_category
 	
 	rural_settlement = yes
 	town = yes
@@ -589,7 +589,7 @@ local_smelters = {
 	employment_size = rural_peasant_enhance_employment
 	
 	
-	category = rgo_building_category
+	category = infrastructure_category
 	
 	rural_settlement = yes
 	town = yes
@@ -640,7 +640,7 @@ sawmill = {
 	employment_size = rural_peasant_enhance_employment
 	
 	
-	category = rgo_building_category
+	category = infrastructure_category
 	
 	rural_settlement = yes
 	town = yes


### PR DESCRIPTION
Solves the issue raised in Discord: https://discord.com/channels/361227452795715584/1546643615818842193/1546643615818842193

## Problem

Buildings that only raise the output of goods in their location — and produce nothing themselves — sat in production categories (`rgo_building_category`, `trade_category`, `consumer_goods_category`, `cultural_category`). Employment systems that staff the most profitable buildings first rank them last, since they have no profit of their own, so their vacancies stayed empty while everything else filled up.

## Change

- `mercury_patio`, `local_smelters`, `windmill`, `sawmill` → `infrastructure_category` in the mod's own files (`common_buildings.txt`, `rural_buildings.txt`).
- `schwaz_mine`, `bubu_building`, `llotja_seda`, `pomor_outpost`, `great_valley_complex`, `trade_company_local_venture` → `infrastructure_category` via `INJECT` in the new `in_game/common/building_types/MnT_building_category_changes.txt` (they are vanilla-defined, and `INJECT` is the mod's convention for partial field overrides).
- Nothing else changes: same `location_potential`, modifiers, production methods, build time, employment size.
- Vanilla already does this for `fulani_cattle_rearing_pen`.

Deliberately not retagged: `ablaq_palace` (its production method produces silk itself), the plantations (produce their own good), `jewish_district` (`local_production_efficiency`, not a goods output modifier), the various build-cost-efficiency buildings.

## Side effects checked

- Location window / production view group buildings by category (`CategoryBuildingTypesItem.GetCategory` in `production_lateralview.gui`), so these buildings now sit under "Infrastructure Buildings" instead of "Raw Material Production" / "Trade" / "Consumer Goods" / "Cultural". Still listed, still buildable; their upkeep now falls under the infrastructure group.
- The "Open RGO builder" button (`goods_production_lateralview.gui:214`) filters by `rgo_building_category`, so they no longer appear in that filtered list. The "show/hide RGO buildings" toggle is unaffected: `mnt_global_hidden_buildings` is filled with explicit `building_type:RGO_building_*` names in `on_action/MnT_pulse.txt`, not by category.
- `epbm_route_building_cost` only special-cases `government_category`, so crown/estate maintenance routing is unchanged for the retagged buildings.
- Vanilla triggers keyed on the old categories now exclude them: `show_production_building_trigger` (consumer goods / weapons / basic industry), `mission_increase_rgo_level` (`rgo_building_category`).
- The location window's producing/non-producing card layout (`BuildingType.IsProducing`) and the RGO slot card (`LocationBuildingItem.IsRGO`, engine RGO functions) are not category-driven, so they are untouched.


Changelog: `Documentation/Change log.md` (Release / Balancing).
